### PR TITLE
Handle empty masks in iterative fit with clear errors

### DIFF
--- a/fit_constant_growth.py
+++ b/fit_constant_growth.py
@@ -96,11 +96,21 @@ def iterative_fit(np, t_years, prices, thresholds: List[float]):
 
     # Step 2: exclude > thresholds[0]
     mask2 = rel1 <= thresholds[0]
+    if not mask2.any():
+        raise RuntimeError(
+            f"No points remain after applying threshold {thresholds[0]:.3f} in step 2; "
+            "try using a larger --thresh2 value."
+        )
     A2, r2 = fit_log_linear(np, t_years[mask2], prices[mask2])
     pred2, rel2 = compute_relative_errors(np, A2, r2, t_years, prices)
 
     # Step 3: exclude > thresholds[1] based on step-2 fit
     mask3 = rel2 <= thresholds[1]
+    if not mask3.any():
+        raise RuntimeError(
+            f"No points remain after applying threshold {thresholds[1]:.3f} in step 3; "
+            "try using a larger --thresh3 value."
+        )
     A3, r3 = fit_log_linear(np, t_years[mask3], prices[mask3])
 
     return (A1, r1, pred1, rel1), (A2, r2, pred2, rel2, mask2), (A3, r3, mask3)

--- a/test_iterative_fit.py
+++ b/test_iterative_fit.py
@@ -1,0 +1,11 @@
+import numpy as np
+import pytest
+
+from fit_constant_growth import iterative_fit
+
+
+def test_iterative_fit_raises_when_no_points_remaining():
+    t = np.array([0.0, 1.0, 2.0])
+    prices = np.array([1.0, 2.0, 1000.0])
+    with pytest.raises(RuntimeError):
+        iterative_fit(np, t, prices, thresholds=[0.0, 0.0])


### PR DESCRIPTION
## Summary
- Guard `iterative_fit` against empty masks in steps 2 and 3
- Add pytest demonstrating RuntimeError when thresholds remove all data

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8a62cd710832da3dcc7e8af6fee74