### PR TITLE
Add macro risk-off filter to TQQQ strategy

### DIFF
--- a/EXPERIMENTS.md
+++ b/EXPERIMENTS.md
@@ -32,3 +32,10 @@ broad uptrends when temperature and rates are acceptable, with an additional
 reverts to the baseline allocation if short‑term returns weaken.
 
 - **CAGR**: ~31.36% (through 2025‑01‑10)
+
+## A5 – Macro Risk-Off Overlay
+Builds on A4 by layering in a macro filter. When the yield curve spread drops
+below –0.2 **and** the credit spread exceeds 2.15, TQQQ exposure is slashed to
+0% until conditions improve, aiming to avoid high‑risk regimes.
+
+- **CAGR**: ~32.16% (through 2025‑01‑10)


### PR DESCRIPTION
## Summary
- rename macro-filter experiment to A5 and base it on A4 parameters
- document new A5 experiment and its improved 32.16% CAGR in EXPERIMENTS.md
- revert strategy plot to prior version to avoid binary diff

## Testing
- `pytest -q`
- `python strategy_tqqq_reserve.py --experiment A1 --no-show`
- `python strategy_tqqq_reserve.py --experiment A5 --no-show`


------
https://chatgpt.com/codex/tasks/task_e_68c5b9cad864832daf8abcc366c213eb