### PR TITLE
Add experiment A7 optimizing option overlay

### DIFF
--- a/EXPERIMENTS.md
+++ b/EXPERIMENTS.md
@@ -58,3 +58,10 @@ with CAGR progressing roughly as follows:
 Using a full overlay maximizes return while cushioning drawdowns.
 
 - **CAGR**: ~39.44% (through 2025‑01‑10)
+
+## A7 – Overlay Cap/Floor Optimization
+Refines A6 by sweeping the option overlay's daily gain cap and loss floor.
+A wider call cap (20%) paired with a tighter put floor (5%) delivers much
+greater growth while retaining downside protection.
+
+- **CAGR**: ~75.05% (through 2025‑01‑10)

--- a/strategy_tqqq_reserve.py
+++ b/strategy_tqqq_reserve.py
@@ -403,6 +403,17 @@ EXPERIMENTS["A6"] = {
     },
 }
 
+# A7 tunes the option overlay caps/floors for better growth
+EXPERIMENTS["A7"] = {
+    **EXPERIMENTS["A6"],
+    "option_overlay": {
+        "fraction": 1.0,
+        "call_cap": 0.20,
+        "put_floor": 0.05,
+        "decay": 0.0002,
+    },
+}
+
 
 def main():
     parser = argparse.ArgumentParser(description="Simulate TQQQ+reserve strategy with temperature & filters")

--- a/test_strategy_experiments.py
+++ b/test_strategy_experiments.py
@@ -29,3 +29,8 @@ def test_a3_cagr():
 def test_a6_cagr():
     cagr = run("A6")
     assert abs(cagr - 39.44) < 0.01
+
+
+def test_a7_cagr():
+    cagr = run("A7")
+    assert abs(cagr - 75.05) < 0.01


### PR DESCRIPTION
## Summary
- Add A7 experiment that optimizes A6's option overlay cap and floor
- Document the new A7 experiment
- Test the expected CAGR for A7

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5c4a43a20832daa567ad1f126e5bc