### PR TITLE
Add base symbol flexibility and cache temperature fits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 __pycache__/
 *.pyc
+symbol_data/
+temperature_cache/

--- a/README.md
+++ b/README.md
@@ -61,9 +61,10 @@ Key capabilities include:
 
 6. **Run the TQQQ + reserve strategy**:
    ```bash
-   python strategy_tqqq_reserve.py --csv unified_nasdaq.csv --experiment A36 --save-plot strategy_tqqq_reserve.png
+   python strategy_tqqq_reserve.py --base-symbol QQQ --csv unified_nasdaq.csv --experiment A36 --save-plot strategy_tqqq_reserve.png
    ```
    By default the CLI executes experiment **A36 – High-Leverage Ramp**, produces two diagnostic plots, and prints summary metrics such as CAGR and rebalance activity; pass `--print-rebalances` or the debug flags to emit detailed trade logs and a per-day CSV for deeper analysis. The helper `analyze_strategy_debug.py` can then surface deployment statistics and rule violations from a debug dump.
+   Provide a different `--base-symbol` (for example `SPY`, `BTC-USD`, `NVDA`) to drive the strategy with another asset. When a non-QQQ base is requested the script downloads the adjusted history via Yahoo Finance, caches it under `symbol_data/`, and stores the fitted temperature parameters plus diagnostic PNGs for reuse.
 
 ## Strategy Experiments
 Strategy configurations are encapsulated in the `EXPERIMENTS` dictionary so features such as cold-temperature leverage boosts, hot-momentum overlays, macro filters, leverage ladders, and rate tapers can be combined without cluttering the core simulation loop. Each entry corresponds to an experiment documented in depth in `EXPERIMENTS.md`, which traces the evolution from the baseline A1 configuration (~29.7% CAGR) to the current A36 high-leverage variant (~45.31% CAGR through 2025‑01‑10). Use `--experiment A#` on the CLI to reproduce any particular configuration.
@@ -93,6 +94,8 @@ Running the pipeline produces a small set of persisted assets:
 - `unified_nasdaq.csv` – unified adjusted closes with their source segment (`QQQ`, `NDX_scaled`, `IXIC_scaled`, etc.).
 - `unified_nasdaq_meta.json` – seam dates, scaling multipliers, and endpoint levels for the unified series, useful when sharing or rerunning analyses.
 - Optional PNG/CSV outputs from the simulators and strategy runs (examples are checked in for reference).
+- `symbol_data/` – cached auto-adjusted closes for any non-QQQ symbols requested by the strategy CLI.
+- `temperature_cache/` – JSON metadata plus PNG diagnostics for per-symbol temperature fits generated on demand.
 
 Because upstream providers revise historical adjustments, re-running `build_unified_nasdaq.py` periodically will refresh the data with updated values; the metadata file records the seam factors applied in each run for transparency.
 

--- a/TASK.md
+++ b/TASK.md
@@ -1,0 +1,18 @@
+# Task Plan
+
+## Objectives
+1. Allow choosing any base symbol/index instead of hard-coded Nasdaq/QQQ when running the strategy.
+2. Fetch and fit data on-demand for new symbols, caching the curve fit and associated visualisations for reuse.
+3. Ensure plots and saved assets reflect the selected base symbol and remain backward compatible for QQQ runs.
+4. Document the new workflow and verify automated tests still pass.
+
+## Plan
+- [x] Review current data loading and temperature fitting flow in `strategy_tqqq_reserve.py` and related modules to identify integration points for symbol overrides.
+- [x] Design caching/layout for per-symbol fits (parameters + PNG outputs) and determine where to generate these assets.
+- [x] Implement CLI updates and data/fit orchestration to support arbitrary symbols, including on-demand yfinance downloads when needed.
+- [x] Update documentation/tests as required and validate the pipeline with pytest.
+
+## Progress
+- [x] Initial analysis complete.
+- [x] Implementation underway.
+- [x] Final validation and documentation updates complete.


### PR DESCRIPTION
## Summary
- allow strategy runs to choose an underlying symbol via --base-symbol and auto-download history when needed
- cache per-symbol temperature fits with accompanying PNG diagnostics and update plot labelling to reflect the base symbol
- document the workflow, track progress in TASK.md, and ignore cached datasets/fit metadata

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cec7ee98f8832d9f57360d8467fc7b