### PR TITLE
Add chart path metadata to symbol stats

### DIFF
--- a/a1_symbol_stats.py
+++ b/a1_symbol_stats.py
@@ -16,6 +16,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.445459,
         "PE_Ratio": 628.93,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/pltr/strategy_pltr_reserve_A1.png',
     },
     "AVGO": {
         "Symbol": "AVGO",
@@ -34,6 +35,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.792856,
         "PE_Ratio": 88.45,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/avgo/strategy_avgo_reserve_A1.png',
     },
     "SHOP": {
         "Symbol": "SHOP",
@@ -52,6 +54,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.449149,
         "PE_Ratio": 85.64,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/shop/strategy_shop_reserve_A1.png',
     },
     "ARM": {
         "Symbol": "ARM",
@@ -70,6 +73,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.764505,
         "PE_Ratio": 216.53,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/arm/strategy_arm_reserve_A1.png',
     },
     "NET": {
         "Symbol": "NET",
@@ -88,6 +92,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.549776,
         "PE_Ratio": 262.72,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/net/strategy_net_reserve_A1.png',
     },
     "GOOGL": {
         "Symbol": "GOOGL",
@@ -106,6 +111,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.78531,
         "PE_Ratio": 27.18,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/googl/strategy_googl_reserve_A1.png',
     },
     "MA": {
         "Symbol": "MA",
@@ -124,6 +130,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.819381,
         "PE_Ratio": 39.36,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/ma/strategy_ma_reserve_A1.png',
     },
     "NVDA": {
         "Symbol": "NVDA",
@@ -142,6 +149,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.385269,
         "PE_Ratio": 50.19,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/nvda/strategy_nvda_reserve_A1.png',
     },
     "NOW": {
         "Symbol": "NOW",
@@ -160,6 +168,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.783125,
         "PE_Ratio": 120.44,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/now/strategy_now_reserve_A1.png',
     },
     "CRWD": {
         "Symbol": "CRWD",
@@ -178,6 +187,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.712175,
         "PE_Ratio": 117.69,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/crwd/strategy_crwd_reserve_A1.png',
     },
     "ADBE": {
         "Symbol": "ADBE",
@@ -196,6 +206,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.637063,
         "PE_Ratio": 22.83,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/adbe/strategy_adbe_reserve_A1.png',
     },
     "ASML": {
         "Symbol": "ASML",
@@ -214,6 +225,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.496898,
         "PE_Ratio": 32.79,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/asml/strategy_asml_reserve_A1.png',
     },
     "TSLA": {
         "Symbol": "TSLA",
@@ -232,6 +244,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.548662,
         "PE_Ratio": 256.67,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/tsla/strategy_tsla_reserve_A1.png',
     },
     "AMZN": {
         "Symbol": "AMZN",
@@ -250,6 +263,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.441889,
         "PE_Ratio": 35.34,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/amzn/strategy_amzn_reserve_A1.png',
     },
     "BLK": {
         "Symbol": "BLK",
@@ -268,6 +282,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.771588,
         "PE_Ratio": 27.63,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/blk/strategy_blk_reserve_A1.png',
     },
     "V": {
         "Symbol": "V",
@@ -286,6 +301,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.846725,
         "PE_Ratio": 33.33,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/v/strategy_v_reserve_A1.png',
     },
     "MSFT": {
         "Symbol": "MSFT",
@@ -304,6 +320,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.44649,
         "PE_Ratio": 38.03,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/msft/strategy_msft_reserve_A1.png',
     },
     "NVO": {
         "Symbol": "NVO",
@@ -322,6 +339,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.626291,
         "PE_Ratio": 15.54,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/nvo/strategy_nvo_reserve_A1.png',
     },
     "HD": {
         "Symbol": "HD",
@@ -340,6 +358,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.457783,
         "PE_Ratio": 28.24,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/hd/strategy_hd_reserve_A1.png',
     },
     "CSCO": {
         "Symbol": "CSCO",
@@ -358,6 +377,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.327551,
         "PE_Ratio": 26.75,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/csco/strategy_csco_reserve_A1.png',
     },
     "DHR": {
         "Symbol": "DHR",
@@ -376,6 +396,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.680363,
         "PE_Ratio": 40.95,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/dhr/strategy_dhr_reserve_A1.png',
     },
     "TMO": {
         "Symbol": "TMO",
@@ -394,6 +415,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.652472,
         "PE_Ratio": 27.71,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/tmo/strategy_tmo_reserve_A1.png',
     },
     "META": {
         "Symbol": "META",
@@ -412,6 +434,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.79007,
         "PE_Ratio": 28.25,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/meta/strategy_meta_reserve_A1.png',
     },
     "TSM": {
         "Symbol": "TSM",
@@ -430,6 +453,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.524152,
         "PE_Ratio": 28.67,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/tsm/strategy_tsm_reserve_A1.png',
     },
     "MO": {
         "Symbol": "MO",
@@ -448,6 +472,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.665692,
         "PE_Ratio": 12.55,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/mo/strategy_mo_reserve_A1.png',
     },
     "INTU": {
         "Symbol": "INTU",
@@ -466,6 +491,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.6749,
         "PE_Ratio": 50.25,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/intu/strategy_intu_reserve_A1.png',
     },
     "OKTA": {
         "Symbol": "OKTA",
@@ -484,6 +510,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.49095,
         "PE_Ratio": 111.15,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/okta/strategy_okta_reserve_A1.png',
     },
     "MCD": {
         "Symbol": "MCD",
@@ -502,6 +529,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.732731,
         "PE_Ratio": 25.91,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/mcd/strategy_mcd_reserve_A1.png',
     },
     "ADP": {
         "Symbol": "ADP",
@@ -520,6 +548,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.687156,
         "PE_Ratio": 29.23,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/adp/strategy_adp_reserve_A1.png',
     },
     "SYK": {
         "Symbol": "SYK",
@@ -538,6 +567,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.576481,
         "PE_Ratio": 49.98,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/syk/strategy_syk_reserve_A1.png',
     },
     "ACN": {
         "Symbol": "ACN",
@@ -556,6 +586,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.845391,
         "PE_Ratio": 19.08,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/acn/strategy_acn_reserve_A1.png',
     },
     "PM": {
         "Symbol": "PM",
@@ -574,6 +605,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.830041,
         "PE_Ratio": 24.11,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/pm/strategy_pm_reserve_A1.png',
     },
     "PANW": {
         "Symbol": "PANW",
@@ -592,6 +624,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.784412,
         "PE_Ratio": 130.12,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/panw/strategy_panw_reserve_A1.png',
     },
     "CRM": {
         "Symbol": "CRM",
@@ -610,6 +643,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.797486,
         "PE_Ratio": 35.97,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/crm/strategy_crm_reserve_A1.png',
     },
     "ABT": {
         "Symbol": "ABT",
@@ -628,6 +662,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.725136,
         "PE_Ratio": 17.07,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/abt/strategy_abt_reserve_A1.png',
     },
     "MMC": {
         "Symbol": "MMC",
@@ -646,6 +681,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.692973,
         "PE_Ratio": 23.65,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/mmc/strategy_mmc_reserve_A1.png',
     },
     "SBUX": {
         "Symbol": "SBUX",
@@ -664,6 +700,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.735602,
         "PE_Ratio": 36.61,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/sbux/strategy_sbux_reserve_A1.png',
     },
     "COST": {
         "Symbol": "COST",
@@ -682,6 +719,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.656105,
         "PE_Ratio": 54.04,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/cost/strategy_cost_reserve_A1.png',
     },
     "ZTS": {
         "Symbol": "ZTS",
@@ -700,6 +738,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.802914,
         "PE_Ratio": 25.11,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/zts/strategy_zts_reserve_A1.png',
     },
     "NKE": {
         "Symbol": "NKE",
@@ -718,6 +757,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.662665,
         "PE_Ratio": 32.82,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/nke/strategy_nke_reserve_A1.png',
     },
     "RTX": {
         "Symbol": "RTX",
@@ -736,6 +776,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.68452,
         "PE_Ratio": 34.7,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/rtx/strategy_rtx_reserve_A1.png',
     },
     "T": {
         "Symbol": "T",
@@ -754,6 +795,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.677408,
         "PE_Ratio": 16.58,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/t/strategy_t_reserve_A1.png',
     },
     "SCHW": {
         "Symbol": "SCHW",
@@ -772,6 +814,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.35699,
         "PE_Ratio": 25.36,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/schw/strategy_schw_reserve_A1.png',
     },
     "ISRG": {
         "Symbol": "ISRG",
@@ -790,6 +833,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.626793,
         "PE_Ratio": 61.36,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/isrg/strategy_isrg_reserve_A1.png',
     },
     "LLY": {
         "Symbol": "LLY",
@@ -808,6 +852,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.556678,
         "PE_Ratio": 49.25,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/lly/strategy_lly_reserve_A1.png',
     },
     "LIN": {
         "Symbol": "LIN",
@@ -826,6 +871,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.822908,
         "PE_Ratio": 34.02,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/lin/strategy_lin_reserve_A1.png',
     },
     "DE": {
         "Symbol": "DE",
@@ -844,6 +890,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.712026,
         "PE_Ratio": 24.51,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/de/strategy_de_reserve_A1.png',
     },
     "AMGN": {
         "Symbol": "AMGN",
@@ -862,6 +909,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.467223,
         "PE_Ratio": 23.32,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/amgn/strategy_amgn_reserve_A1.png',
     },
     "SPGI": {
         "Symbol": "SPGI",
@@ -880,6 +928,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.728385,
         "PE_Ratio": 38.92,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/spgi/strategy_spgi_reserve_A1.png',
     },
     "CB": {
         "Symbol": "CB",
@@ -898,6 +947,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.810835,
         "PE_Ratio": 12.09,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/cb/strategy_cb_reserve_A1.png',
     },
     "WMT": {
         "Symbol": "WMT",
@@ -916,6 +966,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.431049,
         "PE_Ratio": 38.62,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/wmt/strategy_wmt_reserve_A1.png',
     },
     "SO": {
         "Symbol": "SO",
@@ -934,6 +985,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.799691,
         "PE_Ratio": 23.72,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/so/strategy_so_reserve_A1.png',
     },
     "ORCL": {
         "Symbol": "ORCL",
@@ -952,6 +1004,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.414956,
         "PE_Ratio": 71.45,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/orcl/strategy_orcl_reserve_A1.png',
     },
     "BA": {
         "Symbol": "BA",
@@ -970,6 +1023,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.616811,
         "PE_Ratio": 458.83,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/ba/strategy_ba_reserve_A1.png',
     },
     "KO": {
         "Symbol": "KO",
@@ -988,6 +1042,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.529744,
         "PE_Ratio": 23.56,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/ko/strategy_ko_reserve_A1.png',
     },
     "CAT": {
         "Symbol": "CAT",
@@ -1006,6 +1061,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.690914,
         "PE_Ratio": 23.75,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/cat/strategy_cat_reserve_A1.png',
     },
     "GS": {
         "Symbol": "GS",
@@ -1024,6 +1080,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.758195,
         "PE_Ratio": 17.73,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/gs/strategy_gs_reserve_A1.png',
     },
     "DIS": {
         "Symbol": "DIS",
@@ -1042,6 +1099,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.569032,
         "PE_Ratio": 17.83,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/dis/strategy_dis_reserve_A1.png',
     },
     "AMAT": {
         "Symbol": "AMAT",
@@ -1060,6 +1118,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.350814,
         "PE_Ratio": 22.68,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/amat/strategy_amat_reserve_A1.png',
     },
     "MRK": {
         "Symbol": "MRK",
@@ -1078,6 +1137,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.518787,
         "PE_Ratio": 12.56,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/mrk/strategy_mrk_reserve_A1.png',
     },
     "IBM": {
         "Symbol": "IBM",
@@ -1096,6 +1156,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.721534,
         "PE_Ratio": 42.9,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/ibm/strategy_ibm_reserve_A1.png',
     },
     "AXP": {
         "Symbol": "AXP",
@@ -1114,6 +1175,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.657569,
         "PE_Ratio": 23.99,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/axp/strategy_axp_reserve_A1.png',
     },
     "LMT": {
         "Symbol": "LMT",
@@ -1132,6 +1194,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.417777,
         "PE_Ratio": 26.52,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/lmt/strategy_lmt_reserve_A1.png',
     },
     "BK": {
         "Symbol": "BK",
@@ -1150,6 +1213,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.501072,
         "PE_Ratio": 16.62,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/bk/strategy_bk_reserve_A1.png',
     },
     "TXN": {
         "Symbol": "TXN",
@@ -1168,6 +1232,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.576156,
         "PE_Ratio": 32.79,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/txn/strategy_txn_reserve_A1.png',
     },
     "JNJ": {
         "Symbol": "JNJ",
@@ -1186,6 +1251,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.637569,
         "PE_Ratio": 18.86,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/jnj/strategy_jnj_reserve_A1.png',
     },
     "CHTR": {
         "Symbol": "CHTR",
@@ -1204,6 +1270,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.705278,
         "PE_Ratio": 7.19,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/chtr/strategy_chtr_reserve_A1.png',
     },
     "JPM": {
         "Symbol": "JPM",
@@ -1222,6 +1289,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.698793,
         "PE_Ratio": 16.16,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/jpm/strategy_jpm_reserve_A1.png',
     },
     "CMCSA": {
         "Symbol": "CMCSA",
@@ -1240,6 +1308,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.64801,
         "PE_Ratio": 5.24,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/cmcsa/strategy_cmcsa_reserve_A1.png',
     },
     "USB": {
         "Symbol": "USB",
@@ -1258,6 +1327,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.579229,
         "PE_Ratio": 12.06,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/usb/strategy_usb_reserve_A1.png',
     },
     "PG": {
         "Symbol": "PG",
@@ -1276,6 +1346,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.706906,
         "PE_Ratio": 23.97,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/pg/strategy_pg_reserve_A1.png',
     },
     "GE": {
         "Symbol": "GE",
@@ -1294,6 +1365,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.465063,
         "PE_Ratio": 42.9,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/ge/strategy_ge_reserve_A1.png',
     },
     "XOM": {
         "Symbol": "XOM",
@@ -1312,6 +1384,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.676927,
         "PE_Ratio": 16.03,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/xom/strategy_xom_reserve_A1.png',
     },
     "MDLZ": {
         "Symbol": "MDLZ",
@@ -1330,6 +1403,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.83711,
         "PE_Ratio": 23.34,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/mdlz/strategy_mdlz_reserve_A1.png',
     },
     "MS": {
         "Symbol": "MS",
@@ -1348,6 +1422,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.555252,
         "PE_Ratio": 18.11,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/ms/strategy_ms_reserve_A1.png',
     },
     "HON": {
         "Symbol": "HON",
@@ -1366,6 +1441,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.665022,
         "PE_Ratio": 23.82,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/hon/strategy_hon_reserve_A1.png',
     },
     "VZ": {
         "Symbol": "VZ",
@@ -1384,6 +1460,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.763904,
         "PE_Ratio": 10.11,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/vz/strategy_vz_reserve_A1.png',
     },
     "PEP": {
         "Symbol": "PEP",
@@ -1402,6 +1479,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.620871,
         "PE_Ratio": 25.82,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/pep/strategy_pep_reserve_A1.png',
     },
     "AMD": {
         "Symbol": "AMD",
@@ -1420,6 +1498,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.415663,
         "PE_Ratio": 94.25,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/amd/strategy_amd_reserve_A1.png',
     },
     "ZM": {
         "Symbol": "ZM",
@@ -1438,6 +1517,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.468646,
         "PE_Ratio": 22.15,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/zm/strategy_zm_reserve_A1.png',
     },
     "BAC": {
         "Symbol": "BAC",
@@ -1456,6 +1536,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.479547,
         "PE_Ratio": 15.32,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/bac/strategy_bac_reserve_A1.png',
     },
     "BMY": {
         "Symbol": "BMY",
@@ -1474,6 +1555,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.540563,
         "PE_Ratio": 18.08,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/bmy/strategy_bmy_reserve_A1.png',
     },
     "BKNG": {
         "Symbol": "BKNG",
@@ -1492,6 +1574,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.168853,
         "PE_Ratio": 37.88,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/bkng/strategy_bkng_reserve_A1.png',
     },
     "PFE": {
         "Symbol": "PFE",
@@ -1510,6 +1593,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.443779,
         "PE_Ratio": 12.71,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/pfe/strategy_pfe_reserve_A1.png',
     },
     "QCOM": {
         "Symbol": "QCOM",
@@ -1528,6 +1612,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.50312,
         "PE_Ratio": 16.11,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/qcom/strategy_qcom_reserve_A1.png',
     },
     "GILD": {
         "Symbol": "GILD",
@@ -1546,6 +1631,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.605332,
         "PE_Ratio": 22.64,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/gild/strategy_gild_reserve_A1.png',
     },
     "PYPL": {
         "Symbol": "PYPL",
@@ -1564,6 +1650,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.544042,
         "PE_Ratio": 14.61,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/pypl/strategy_pypl_reserve_A1.png',
     },
     "UPS": {
         "Symbol": "UPS",
@@ -1582,6 +1669,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.819558,
         "PE_Ratio": 12.51,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/ups/strategy_ups_reserve_A1.png',
     },
     "TEAM": {
         "Symbol": "TEAM",
@@ -1600,6 +1688,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.591834,
         "PE_Ratio": 41.13,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/team/strategy_team_reserve_A1.png',
     },
     "INTC": {
         "Symbol": "INTC",
@@ -1618,6 +1707,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.3689,
         "PE_Ratio": 30.49,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/intc/strategy_intc_reserve_A1.png',
     },
     "C": {
         "Symbol": "C",
@@ -1636,6 +1726,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.239356,
         "PE_Ratio": 15.17,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/c/strategy_c_reserve_A1.png',
     },
     "MU": {
         "Symbol": "MU",
@@ -1654,6 +1745,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.347573,
         "PE_Ratio": 29.32,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/mu/strategy_mu_reserve_A1.png',
     },
     "DDOG": {
         "Symbol": "DDOG",
@@ -1672,6 +1764,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.753746,
         "PE_Ratio": 385.61,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/ddog/strategy_ddog_reserve_A1.png',
     },
     "SNOW": {
         "Symbol": "SNOW",
@@ -1690,6 +1783,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.76019,
         "PE_Ratio": 247.83,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/snow/strategy_snow_reserve_A1.png',
     },
     "AAPL": {
         "Symbol": "AAPL",
@@ -1708,6 +1802,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.481752,
         "PE_Ratio": 37.31,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/aapl/strategy_aapl_reserve_A1.png',
     },
     "UNH": {
         "Symbol": "UNH",
@@ -1726,6 +1821,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.555614,
         "PE_Ratio": 14.58,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/unh/strategy_unh_reserve_A1.png',
     },
     "NFLX": {
         "Symbol": "NFLX",
@@ -1744,6 +1840,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.621519,
         "PE_Ratio": 52.35,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/nflx/strategy_nflx_reserve_A1.png',
     },
     "TTD": {
         "Symbol": "TTD",
@@ -1762,6 +1859,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.578926,
         "PE_Ratio": 53.58,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/ttd/strategy_ttd_reserve_A1.png',
     },
     "SMCI": {
         "Symbol": "SMCI",
@@ -1780,6 +1878,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.388124,
         "PE_Ratio": 27.27,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/smci/strategy_smci_reserve_A1.png',
     },
     "ENPH": {
         "Symbol": "ENPH",
@@ -1798,5 +1897,6 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.389706,
         "PE_Ratio": 29.78,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/enph/strategy_enph_reserve_A1.png',
     },
 }

--- a/a1g_symbol_stats.py
+++ b/a1g_symbol_stats.py
@@ -16,6 +16,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.445459,
         "PE_Ratio": 628.93,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/pltr/strategy_pltr_reserve_A1g.png',
     },
     "CRWD": {
         "Symbol": "CRWD",
@@ -34,6 +35,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.712175,
         "PE_Ratio": 117.69,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/crwd/strategy_crwd_reserve_A1g.png',
     },
     "SHOP": {
         "Symbol": "SHOP",
@@ -52,6 +54,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.449149,
         "PE_Ratio": 85.64,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/shop/strategy_shop_reserve_A1g.png',
     },
     "ARM": {
         "Symbol": "ARM",
@@ -70,6 +73,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.764505,
         "PE_Ratio": 216.53,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/arm/strategy_arm_reserve_A1g.png',
     },
     "NET": {
         "Symbol": "NET",
@@ -88,6 +92,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.549776,
         "PE_Ratio": 262.72,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/net/strategy_net_reserve_A1g.png',
     },
     "AVGO": {
         "Symbol": "AVGO",
@@ -106,6 +111,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.792856,
         "PE_Ratio": 88.45,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/avgo/strategy_avgo_reserve_A1g.png',
     },
     "TSLA": {
         "Symbol": "TSLA",
@@ -124,6 +130,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.548662,
         "PE_Ratio": 256.67,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/tsla/strategy_tsla_reserve_A1g.png',
     },
     "GOOGL": {
         "Symbol": "GOOGL",
@@ -142,6 +149,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.78531,
         "PE_Ratio": 27.18,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/googl/strategy_googl_reserve_A1g.png',
     },
     "NVDA": {
         "Symbol": "NVDA",
@@ -160,6 +168,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.385269,
         "PE_Ratio": 50.19,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/nvda/strategy_nvda_reserve_A1g.png',
     },
     "MA": {
         "Symbol": "MA",
@@ -178,6 +187,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.819381,
         "PE_Ratio": 39.36,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/ma/strategy_ma_reserve_A1g.png',
     },
     "NOW": {
         "Symbol": "NOW",
@@ -196,6 +206,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.783125,
         "PE_Ratio": 120.44,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/now/strategy_now_reserve_A1g.png',
     },
     "ADBE": {
         "Symbol": "ADBE",
@@ -214,6 +225,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.637063,
         "PE_Ratio": 22.83,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/adbe/strategy_adbe_reserve_A1g.png',
     },
     "NFLX": {
         "Symbol": "NFLX",
@@ -232,6 +244,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.621519,
         "PE_Ratio": 52.35,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/nflx/strategy_nflx_reserve_A1g.png',
     },
     "AMZN": {
         "Symbol": "AMZN",
@@ -250,6 +263,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.441889,
         "PE_Ratio": 35.34,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/amzn/strategy_amzn_reserve_A1g.png',
     },
     "PANW": {
         "Symbol": "PANW",
@@ -268,6 +282,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.784412,
         "PE_Ratio": 130.12,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/panw/strategy_panw_reserve_A1g.png',
     },
     "CSCO": {
         "Symbol": "CSCO",
@@ -286,6 +301,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.327551,
         "PE_Ratio": 26.75,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/csco/strategy_csco_reserve_A1g.png',
     },
     "ASML": {
         "Symbol": "ASML",
@@ -304,6 +320,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.496898,
         "PE_Ratio": 32.79,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/asml/strategy_asml_reserve_A1g.png',
     },
     "BLK": {
         "Symbol": "BLK",
@@ -322,6 +339,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.771588,
         "PE_Ratio": 27.63,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/blk/strategy_blk_reserve_A1g.png',
     },
     "MSFT": {
         "Symbol": "MSFT",
@@ -340,6 +358,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.44649,
         "PE_Ratio": 38.03,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/msft/strategy_msft_reserve_A1g.png',
     },
     "META": {
         "Symbol": "META",
@@ -358,6 +377,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.79007,
         "PE_Ratio": 28.25,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/meta/strategy_meta_reserve_A1g.png',
     },
     "V": {
         "Symbol": "V",
@@ -376,6 +396,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.846725,
         "PE_Ratio": 33.33,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/v/strategy_v_reserve_A1g.png',
     },
     "CRM": {
         "Symbol": "CRM",
@@ -394,6 +415,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.797486,
         "PE_Ratio": 35.97,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/crm/strategy_crm_reserve_A1g.png',
     },
     "HD": {
         "Symbol": "HD",
@@ -412,6 +434,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.457783,
         "PE_Ratio": 28.24,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/hd/strategy_hd_reserve_A1g.png',
     },
     "OKTA": {
         "Symbol": "OKTA",
@@ -430,6 +453,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.49095,
         "PE_Ratio": 111.15,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/okta/strategy_okta_reserve_A1g.png',
     },
     "DHR": {
         "Symbol": "DHR",
@@ -448,6 +472,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.680363,
         "PE_Ratio": 40.95,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/dhr/strategy_dhr_reserve_A1g.png',
     },
     "INTU": {
         "Symbol": "INTU",
@@ -466,6 +491,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.6749,
         "PE_Ratio": 50.25,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/intu/strategy_intu_reserve_A1g.png',
     },
     "NVO": {
         "Symbol": "NVO",
@@ -484,6 +510,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.626291,
         "PE_Ratio": 15.54,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/nvo/strategy_nvo_reserve_A1g.png',
     },
     "DDOG": {
         "Symbol": "DDOG",
@@ -502,6 +529,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.753746,
         "PE_Ratio": 385.61,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/ddog/strategy_ddog_reserve_A1g.png',
     },
     "TSM": {
         "Symbol": "TSM",
@@ -520,6 +548,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.524152,
         "PE_Ratio": 28.67,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/tsm/strategy_tsm_reserve_A1g.png',
     },
     "TMO": {
         "Symbol": "TMO",
@@ -538,6 +567,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.652472,
         "PE_Ratio": 27.71,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/tmo/strategy_tmo_reserve_A1g.png',
     },
     "ISRG": {
         "Symbol": "ISRG",
@@ -556,6 +586,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.626793,
         "PE_Ratio": 61.36,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/isrg/strategy_isrg_reserve_A1g.png',
     },
     "MO": {
         "Symbol": "MO",
@@ -574,6 +605,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.665692,
         "PE_Ratio": 12.55,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/mo/strategy_mo_reserve_A1g.png',
     },
     "ACN": {
         "Symbol": "ACN",
@@ -592,6 +624,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.845391,
         "PE_Ratio": 19.08,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/acn/strategy_acn_reserve_A1g.png',
     },
     "ORCL": {
         "Symbol": "ORCL",
@@ -610,6 +643,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.414956,
         "PE_Ratio": 71.45,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/orcl/strategy_orcl_reserve_A1g.png',
     },
     "SYK": {
         "Symbol": "SYK",
@@ -628,6 +662,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.576481,
         "PE_Ratio": 49.98,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/syk/strategy_syk_reserve_A1g.png',
     },
     "SBUX": {
         "Symbol": "SBUX",
@@ -646,6 +681,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.735602,
         "PE_Ratio": 36.61,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/sbux/strategy_sbux_reserve_A1g.png',
     },
     "MCD": {
         "Symbol": "MCD",
@@ -664,6 +700,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.732731,
         "PE_Ratio": 25.91,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/mcd/strategy_mcd_reserve_A1g.png',
     },
     "ABT": {
         "Symbol": "ABT",
@@ -682,6 +719,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.725136,
         "PE_Ratio": 17.07,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/abt/strategy_abt_reserve_A1g.png',
     },
     "SPGI": {
         "Symbol": "SPGI",
@@ -700,6 +738,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.728385,
         "PE_Ratio": 38.92,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/spgi/strategy_spgi_reserve_A1g.png',
     },
     "LIN": {
         "Symbol": "LIN",
@@ -718,6 +757,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.822908,
         "PE_Ratio": 34.02,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/lin/strategy_lin_reserve_A1g.png',
     },
     "ADP": {
         "Symbol": "ADP",
@@ -736,6 +776,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.687156,
         "PE_Ratio": 29.23,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/adp/strategy_adp_reserve_A1g.png',
     },
     "AMGN": {
         "Symbol": "AMGN",
@@ -754,6 +795,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.467223,
         "PE_Ratio": 23.32,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/amgn/strategy_amgn_reserve_A1g.png',
     },
     "SCHW": {
         "Symbol": "SCHW",
@@ -772,6 +814,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.35699,
         "PE_Ratio": 25.36,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/schw/strategy_schw_reserve_A1g.png',
     },
     "WMT": {
         "Symbol": "WMT",
@@ -790,6 +833,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.431049,
         "PE_Ratio": 38.62,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/wmt/strategy_wmt_reserve_A1g.png',
     },
     "PM": {
         "Symbol": "PM",
@@ -808,6 +852,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.830041,
         "PE_Ratio": 24.11,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/pm/strategy_pm_reserve_A1g.png',
     },
     "COST": {
         "Symbol": "COST",
@@ -826,6 +871,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.656105,
         "PE_Ratio": 54.04,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/cost/strategy_cost_reserve_A1g.png',
     },
     "ZTS": {
         "Symbol": "ZTS",
@@ -844,6 +890,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.802914,
         "PE_Ratio": 25.11,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/zts/strategy_zts_reserve_A1g.png',
     },
     "MMC": {
         "Symbol": "MMC",
@@ -862,6 +909,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.692973,
         "PE_Ratio": 23.65,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/mmc/strategy_mmc_reserve_A1g.png',
     },
     "LLY": {
         "Symbol": "LLY",
@@ -880,6 +928,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.556678,
         "PE_Ratio": 49.25,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/lly/strategy_lly_reserve_A1g.png',
     },
     "GS": {
         "Symbol": "GS",
@@ -898,6 +947,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.758195,
         "PE_Ratio": 17.73,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/gs/strategy_gs_reserve_A1g.png',
     },
     "NKE": {
         "Symbol": "NKE",
@@ -916,6 +966,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.662665,
         "PE_Ratio": 32.82,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/nke/strategy_nke_reserve_A1g.png',
     },
     "DIS": {
         "Symbol": "DIS",
@@ -934,6 +985,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.569032,
         "PE_Ratio": 17.83,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/dis/strategy_dis_reserve_A1g.png',
     },
     "DE": {
         "Symbol": "DE",
@@ -952,6 +1004,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.712026,
         "PE_Ratio": 24.51,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/de/strategy_de_reserve_A1g.png',
     },
     "RTX": {
         "Symbol": "RTX",
@@ -970,6 +1023,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.68452,
         "PE_Ratio": 34.7,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/rtx/strategy_rtx_reserve_A1g.png',
     },
     "AMAT": {
         "Symbol": "AMAT",
@@ -988,6 +1042,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.350814,
         "PE_Ratio": 22.68,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/amat/strategy_amat_reserve_A1g.png',
     },
     "TEAM": {
         "Symbol": "TEAM",
@@ -1006,6 +1061,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.591834,
         "PE_Ratio": 41.13,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/team/strategy_team_reserve_A1g.png',
     },
     "SO": {
         "Symbol": "SO",
@@ -1024,6 +1080,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.799691,
         "PE_Ratio": 23.72,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/so/strategy_so_reserve_A1g.png',
     },
     "T": {
         "Symbol": "T",
@@ -1042,6 +1099,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.677408,
         "PE_Ratio": 16.58,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/t/strategy_t_reserve_A1g.png',
     },
     "CB": {
         "Symbol": "CB",
@@ -1060,6 +1118,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.810835,
         "PE_Ratio": 12.09,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/cb/strategy_cb_reserve_A1g.png',
     },
     "CMCSA": {
         "Symbol": "CMCSA",
@@ -1078,6 +1137,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.64801,
         "PE_Ratio": 5.24,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/cmcsa/strategy_cmcsa_reserve_A1g.png',
     },
     "MRK": {
         "Symbol": "MRK",
@@ -1096,6 +1156,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.518787,
         "PE_Ratio": 12.56,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/mrk/strategy_mrk_reserve_A1g.png',
     },
     "KO": {
         "Symbol": "KO",
@@ -1114,6 +1175,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.529744,
         "PE_Ratio": 23.56,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/ko/strategy_ko_reserve_A1g.png',
     },
     "QCOM": {
         "Symbol": "QCOM",
@@ -1132,6 +1194,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.50312,
         "PE_Ratio": 16.11,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/qcom/strategy_qcom_reserve_A1g.png',
     },
     "AXP": {
         "Symbol": "AXP",
@@ -1150,6 +1213,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.657569,
         "PE_Ratio": 23.99,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/axp/strategy_axp_reserve_A1g.png',
     },
     "JNJ": {
         "Symbol": "JNJ",
@@ -1168,6 +1232,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.637569,
         "PE_Ratio": 18.86,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/jnj/strategy_jnj_reserve_A1g.png',
     },
     "TXN": {
         "Symbol": "TXN",
@@ -1186,6 +1251,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.576156,
         "PE_Ratio": 32.79,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/txn/strategy_txn_reserve_A1g.png',
     },
     "BA": {
         "Symbol": "BA",
@@ -1204,6 +1270,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.616811,
         "PE_Ratio": 458.83,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/ba/strategy_ba_reserve_A1g.png',
     },
     "CAT": {
         "Symbol": "CAT",
@@ -1222,6 +1289,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.690914,
         "PE_Ratio": 23.75,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/cat/strategy_cat_reserve_A1g.png',
     },
     "JPM": {
         "Symbol": "JPM",
@@ -1240,6 +1308,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.698793,
         "PE_Ratio": 16.16,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/jpm/strategy_jpm_reserve_A1g.png',
     },
     "IBM": {
         "Symbol": "IBM",
@@ -1258,6 +1327,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.721534,
         "PE_Ratio": 42.9,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/ibm/strategy_ibm_reserve_A1g.png',
     },
     "UNH": {
         "Symbol": "UNH",
@@ -1276,6 +1346,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.555614,
         "PE_Ratio": 14.58,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/unh/strategy_unh_reserve_A1g.png',
     },
     "BK": {
         "Symbol": "BK",
@@ -1294,6 +1365,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.501072,
         "PE_Ratio": 16.62,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/bk/strategy_bk_reserve_A1g.png',
     },
     "PYPL": {
         "Symbol": "PYPL",
@@ -1312,6 +1384,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.544042,
         "PE_Ratio": 14.61,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/pypl/strategy_pypl_reserve_A1g.png',
     },
     "MS": {
         "Symbol": "MS",
@@ -1330,6 +1403,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.555252,
         "PE_Ratio": 18.11,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/ms/strategy_ms_reserve_A1g.png',
     },
     "PG": {
         "Symbol": "PG",
@@ -1348,6 +1422,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.706906,
         "PE_Ratio": 23.97,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/pg/strategy_pg_reserve_A1g.png',
     },
     "USB": {
         "Symbol": "USB",
@@ -1366,6 +1441,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.579229,
         "PE_Ratio": 12.06,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/usb/strategy_usb_reserve_A1g.png',
     },
     "BKNG": {
         "Symbol": "BKNG",
@@ -1384,6 +1460,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.168853,
         "PE_Ratio": 37.88,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/bkng/strategy_bkng_reserve_A1g.png',
     },
     "VZ": {
         "Symbol": "VZ",
@@ -1402,6 +1479,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.763904,
         "PE_Ratio": 10.11,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/vz/strategy_vz_reserve_A1g.png',
     },
     "BAC": {
         "Symbol": "BAC",
@@ -1420,6 +1498,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.479547,
         "PE_Ratio": 15.32,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/bac/strategy_bac_reserve_A1g.png',
     },
     "MDLZ": {
         "Symbol": "MDLZ",
@@ -1438,6 +1517,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.83711,
         "PE_Ratio": 23.34,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/mdlz/strategy_mdlz_reserve_A1g.png',
     },
     "CHTR": {
         "Symbol": "CHTR",
@@ -1456,6 +1536,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.705278,
         "PE_Ratio": 7.19,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/chtr/strategy_chtr_reserve_A1g.png',
     },
     "GE": {
         "Symbol": "GE",
@@ -1474,6 +1555,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.465063,
         "PE_Ratio": 42.9,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/ge/strategy_ge_reserve_A1g.png',
     },
     "HON": {
         "Symbol": "HON",
@@ -1492,6 +1574,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.665022,
         "PE_Ratio": 23.82,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/hon/strategy_hon_reserve_A1g.png',
     },
     "PEP": {
         "Symbol": "PEP",
@@ -1510,6 +1593,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.620871,
         "PE_Ratio": 25.82,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/pep/strategy_pep_reserve_A1g.png',
     },
     "XOM": {
         "Symbol": "XOM",
@@ -1528,6 +1612,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.676927,
         "PE_Ratio": 16.03,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/xom/strategy_xom_reserve_A1g.png',
     },
     "AMD": {
         "Symbol": "AMD",
@@ -1546,6 +1631,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.415663,
         "PE_Ratio": 94.25,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/amd/strategy_amd_reserve_A1g.png',
     },
     "LMT": {
         "Symbol": "LMT",
@@ -1564,6 +1650,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.417777,
         "PE_Ratio": 26.52,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/lmt/strategy_lmt_reserve_A1g.png',
     },
     "BMY": {
         "Symbol": "BMY",
@@ -1582,6 +1669,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.540563,
         "PE_Ratio": 18.08,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/bmy/strategy_bmy_reserve_A1g.png',
     },
     "GILD": {
         "Symbol": "GILD",
@@ -1600,6 +1688,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.605332,
         "PE_Ratio": 22.64,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/gild/strategy_gild_reserve_A1g.png',
     },
     "INTC": {
         "Symbol": "INTC",
@@ -1618,6 +1707,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.3689,
         "PE_Ratio": 30.49,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/intc/strategy_intc_reserve_A1g.png',
     },
     "PFE": {
         "Symbol": "PFE",
@@ -1636,6 +1726,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.443779,
         "PE_Ratio": 12.71,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/pfe/strategy_pfe_reserve_A1g.png',
     },
     "ZM": {
         "Symbol": "ZM",
@@ -1654,6 +1745,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.468646,
         "PE_Ratio": 22.15,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/zm/strategy_zm_reserve_A1g.png',
     },
     "UPS": {
         "Symbol": "UPS",
@@ -1672,6 +1764,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.819558,
         "PE_Ratio": 12.51,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/ups/strategy_ups_reserve_A1g.png',
     },
     "C": {
         "Symbol": "C",
@@ -1690,6 +1783,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.239356,
         "PE_Ratio": 15.17,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/c/strategy_c_reserve_A1g.png',
     },
     "MU": {
         "Symbol": "MU",
@@ -1708,6 +1802,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.347573,
         "PE_Ratio": 29.32,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/mu/strategy_mu_reserve_A1g.png',
     },
     "SNOW": {
         "Symbol": "SNOW",
@@ -1726,6 +1821,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.76019,
         "PE_Ratio": 247.83,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/snow/strategy_snow_reserve_A1g.png',
     },
     "ENPH": {
         "Symbol": "ENPH",
@@ -1744,6 +1840,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.389706,
         "PE_Ratio": 29.78,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/enph/strategy_enph_reserve_A1g.png',
     },
     "AAPL": {
         "Symbol": "AAPL",
@@ -1762,6 +1859,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.481752,
         "PE_Ratio": 37.31,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/aapl/strategy_aapl_reserve_A1g.png',
     },
     "TTD": {
         "Symbol": "TTD",
@@ -1780,6 +1878,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.578926,
         "PE_Ratio": 53.58,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/ttd/strategy_ttd_reserve_A1g.png',
     },
     "SMCI": {
         "Symbol": "SMCI",
@@ -1798,5 +1897,6 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.388124,
         "PE_Ratio": 27.27,
         "PE_Ratio_As_Of": '2025-09-21',
+        "Strategy_Chart_Path": 'symbols/smci/strategy_smci_reserve_A1g.png',
     },
 }

--- a/scripts/render_symbol_tables.py
+++ b/scripts/render_symbol_tables.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Render Markdown tables for the cached A1 and A1g symbol statistics."""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import Mapping
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+from a1_symbol_stats import A1_SYMBOL_STATS
+from a1g_symbol_stats import A1G_SYMBOL_STATS
+
+
+def _format_percent(value: object) -> str:
+    if isinstance(value, (int, float)):
+        return f"{float(value) * 100:.2f}%"
+    return "—"
+
+
+def _format_chart_link(path: object) -> str:
+    if isinstance(path, str) and path:
+        return f"[Strategy Chart]({path})"
+    return "—"
+
+
+def _render_table(stats: Mapping[str, Mapping[str, object]]) -> str:
+    headers = ["Symbol", "Name", "Strategy CAGR", "Max Drawdown", "Strategy Chart"]
+    lines = [" | ".join(headers), " | ".join(["---"] * len(headers))]
+    for symbol, payload in stats.items():
+        lines.append(
+            " | ".join(
+                [
+                    symbol,
+                    str(payload.get("Name", "")),
+                    _format_percent(payload.get("Strategy_CAGR")),
+                    _format_percent(payload.get("Max_Drawdown")),
+                    _format_chart_link(payload.get("Strategy_Chart_Path")),
+                ]
+            )
+        )
+    return "\n".join(lines)
+
+
+def main() -> None:
+    print("# A1 Symbol Stats")
+    print(_render_table(A1_SYMBOL_STATS))
+    print()  # Spacer between tables
+    print("# A1g Symbol Stats")
+    print(_render_table(A1G_SYMBOL_STATS))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- capture the per-symbol strategy plot path when ensuring assets and thread it through the exported stats payloads
- regenerate the cached A1 and A1g symbol stats so each entry advertises its own Strategy_Chart_Path
- add a helper to render Markdown tables that link to the correct chart image for every symbol instead of falling back to the TQQQ plot

## Testing
- python generate_a1_symbol_stats.py
- python scripts/render_symbol_tables.py > /tmp/summary.md

------
https://chatgpt.com/codex/tasks/task_e_68cffce8661c832d9229b09fa79211c4