### PR TITLE
Populate PEG ratios from Finviz fallback

### DIFF
--- a/a1_symbol_stats.py
+++ b/a1_symbol_stats.py
@@ -16,6 +16,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.445459,
         "PE_Ratio": 628.93,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 15.05,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "AVGO": {
         "Symbol": "AVGO",
@@ -34,6 +36,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.792856,
         "PE_Ratio": 88.45,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 2.63,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "SHOP": {
         "Symbol": "SHOP",
@@ -52,6 +56,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.449149,
         "PE_Ratio": 85.64,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 3.67,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "ARM": {
         "Symbol": "ARM",
@@ -70,6 +76,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.764505,
         "PE_Ratio": 216.53,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 10.62,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "NET": {
         "Symbol": "NET",
@@ -88,6 +96,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.549776,
         "PE_Ratio": 262.72,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 10.45,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "GOOGL": {
         "Symbol": "GOOGL",
@@ -106,6 +116,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.78531,
         "PE_Ratio": 27.18,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 1.84,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "MA": {
         "Symbol": "MA",
@@ -124,6 +136,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.819381,
         "PE_Ratio": 39.36,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 2.64,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "NVDA": {
         "Symbol": "NVDA",
@@ -142,6 +156,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.385269,
         "PE_Ratio": 50.19,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 1.44,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "NOW": {
         "Symbol": "NOW",
@@ -160,6 +176,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.783125,
         "PE_Ratio": 120.44,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 5.99,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "CRWD": {
         "Symbol": "CRWD",
@@ -178,6 +196,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.712175,
         "PE_Ratio": 117.69,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 7.24,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "ADBE": {
         "Symbol": "ADBE",
@@ -196,6 +216,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.637063,
         "PE_Ratio": 22.83,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 1.81,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "ASML": {
         "Symbol": "ASML",
@@ -214,6 +236,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.496898,
         "PE_Ratio": 32.79,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 1.73,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "TSLA": {
         "Symbol": "TSLA",
@@ -232,6 +256,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.548662,
         "PE_Ratio": 256.67,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 17.65,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "AMZN": {
         "Symbol": "AMZN",
@@ -250,6 +276,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.441889,
         "PE_Ratio": 35.34,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 1.9,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "BLK": {
         "Symbol": "BLK",
@@ -268,6 +296,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.771588,
         "PE_Ratio": 27.63,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 2.47,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "V": {
         "Symbol": "V",
@@ -286,6 +316,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.846725,
         "PE_Ratio": 33.33,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 2.59,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "MSFT": {
         "Symbol": "MSFT",
@@ -304,6 +336,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.44649,
         "PE_Ratio": 38.03,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 2.28,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "NVO": {
         "Symbol": "NVO",
@@ -322,6 +356,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.626291,
         "PE_Ratio": 15.54,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 1.34,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "HD": {
         "Symbol": "HD",
@@ -340,6 +376,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.457783,
         "PE_Ratio": 28.24,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 5.35,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "CSCO": {
         "Symbol": "CSCO",
@@ -358,6 +396,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.327551,
         "PE_Ratio": 26.75,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 4.68,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "DHR": {
         "Symbol": "DHR",
@@ -376,6 +416,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.680363,
         "PE_Ratio": 40.95,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 5.01,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "TMO": {
         "Symbol": "TMO",
@@ -394,6 +436,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.652472,
         "PE_Ratio": 27.71,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 3.88,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "META": {
         "Symbol": "META",
@@ -412,6 +456,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.79007,
         "PE_Ratio": 28.25,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 2.2,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "TSM": {
         "Symbol": "TSM",
@@ -430,6 +476,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.524152,
         "PE_Ratio": 28.67,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 1.21,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "MO": {
         "Symbol": "MO",
@@ -448,6 +496,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.665692,
         "PE_Ratio": 12.55,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 2.91,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "INTU": {
         "Symbol": "INTU",
@@ -466,6 +516,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.6749,
         "PE_Ratio": 50.25,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 3.45,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "OKTA": {
         "Symbol": "OKTA",
@@ -484,6 +536,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.49095,
         "PE_Ratio": 111.15,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 8.9,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "MCD": {
         "Symbol": "MCD",
@@ -502,6 +556,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.732731,
         "PE_Ratio": 25.91,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 3.54,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "ADP": {
         "Symbol": "ADP",
@@ -520,6 +576,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.687156,
         "PE_Ratio": 29.23,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 3.09,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "SYK": {
         "Symbol": "SYK",
@@ -538,6 +596,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.576481,
         "PE_Ratio": 49.98,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 4.48,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "ACN": {
         "Symbol": "ACN",
@@ -556,6 +616,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.845391,
         "PE_Ratio": 19.08,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 2.49,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "PM": {
         "Symbol": "PM",
@@ -574,6 +636,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.830041,
         "PE_Ratio": 24.11,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 2.62,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "PANW": {
         "Symbol": "PANW",
@@ -592,6 +656,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.784412,
         "PE_Ratio": 130.12,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 9.69,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "CRM": {
         "Symbol": "CRM",
@@ -610,6 +676,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.797486,
         "PE_Ratio": 35.97,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 2.88,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "ABT": {
         "Symbol": "ABT",
@@ -628,6 +696,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.725136,
         "PE_Ratio": 17.07,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 1.65,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "MMC": {
         "Symbol": "MMC",
@@ -646,6 +716,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.692973,
         "PE_Ratio": 23.65,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 2.71,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "SBUX": {
         "Symbol": "SBUX",
@@ -664,6 +736,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.735602,
         "PE_Ratio": 36.61,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 110.82,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "COST": {
         "Symbol": "COST",
@@ -682,6 +756,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.656105,
         "PE_Ratio": 54.04,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 5.27,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "ZTS": {
         "Symbol": "ZTS",
@@ -700,6 +776,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.802914,
         "PE_Ratio": 25.11,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 2.97,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "NKE": {
         "Symbol": "NKE",
@@ -718,6 +796,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.662665,
         "PE_Ratio": 32.82,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 3.33,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "RTX": {
         "Symbol": "RTX",
@@ -736,6 +816,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.68452,
         "PE_Ratio": 34.7,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 3.77,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "T": {
         "Symbol": "T",
@@ -754,6 +836,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.677408,
         "PE_Ratio": 16.58,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 4.71,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "SCHW": {
         "Symbol": "SCHW",
@@ -772,6 +856,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.35699,
         "PE_Ratio": 25.36,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 1.04,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "ISRG": {
         "Symbol": "ISRG",
@@ -790,6 +876,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.626793,
         "PE_Ratio": 61.36,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 4.49,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "LLY": {
         "Symbol": "LLY",
@@ -808,6 +896,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.556678,
         "PE_Ratio": 49.25,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 1.2,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "LIN": {
         "Symbol": "LIN",
@@ -826,6 +916,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.822908,
         "PE_Ratio": 34.02,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 4.15,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "DE": {
         "Symbol": "DE",
@@ -844,6 +936,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.712026,
         "PE_Ratio": 24.51,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 1.73,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "AMGN": {
         "Symbol": "AMGN",
@@ -862,6 +956,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.467223,
         "PE_Ratio": 23.32,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 5.59,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "SPGI": {
         "Symbol": "SPGI",
@@ -880,6 +976,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.728385,
         "PE_Ratio": 38.92,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 3.51,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "CB": {
         "Symbol": "CB",
@@ -898,6 +996,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.810835,
         "PE_Ratio": 12.09,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 1.64,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "WMT": {
         "Symbol": "WMT",
@@ -916,6 +1016,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.431049,
         "PE_Ratio": 38.62,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 4.12,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "SO": {
         "Symbol": "SO",
@@ -934,6 +1036,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.799691,
         "PE_Ratio": 23.72,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 3.51,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "ORCL": {
         "Symbol": "ORCL",
@@ -952,6 +1056,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.414956,
         "PE_Ratio": 71.45,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 3.11,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "BA": {
         "Symbol": "BA",
@@ -970,6 +1076,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.616811,
         "PE_Ratio": 458.83,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 1.91,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "KO": {
         "Symbol": "KO",
@@ -988,6 +1096,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.529744,
         "PE_Ratio": 23.56,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 3.76,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "CAT": {
         "Symbol": "CAT",
@@ -1006,6 +1116,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.690914,
         "PE_Ratio": 23.75,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 5.25,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "GS": {
         "Symbol": "GS",
@@ -1024,6 +1136,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.758195,
         "PE_Ratio": 17.73,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 1.28,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "DIS": {
         "Symbol": "DIS",
@@ -1042,6 +1156,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.569032,
         "PE_Ratio": 17.83,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 1.31,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "AMAT": {
         "Symbol": "AMAT",
@@ -1060,6 +1176,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.350814,
         "PE_Ratio": 22.68,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 3.18,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "MRK": {
         "Symbol": "MRK",
@@ -1078,6 +1196,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.518787,
         "PE_Ratio": 12.56,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 1.13,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "IBM": {
         "Symbol": "IBM",
@@ -1096,6 +1216,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.721534,
         "PE_Ratio": 42.9,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 6.04,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "AXP": {
         "Symbol": "AXP",
@@ -1114,6 +1236,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.657569,
         "PE_Ratio": 23.99,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 2.06,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "LMT": {
         "Symbol": "LMT",
@@ -1132,6 +1256,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.417777,
         "PE_Ratio": 26.52,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 2.18,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "BK": {
         "Symbol": "BK",
@@ -1150,6 +1276,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.501072,
         "PE_Ratio": 16.62,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 1.14,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "TXN": {
         "Symbol": "TXN",
@@ -1168,6 +1296,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.576156,
         "PE_Ratio": 32.79,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 2.27,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "JNJ": {
         "Symbol": "JNJ",
@@ -1186,6 +1316,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.637569,
         "PE_Ratio": 18.86,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 2.85,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "CHTR": {
         "Symbol": "CHTR",
@@ -1204,6 +1336,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.705278,
         "PE_Ratio": 7.19,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 0.59,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "JPM": {
         "Symbol": "JPM",
@@ -1222,6 +1356,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.698793,
         "PE_Ratio": 16.16,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 2.47,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "CMCSA": {
         "Symbol": "CMCSA",
@@ -1240,6 +1376,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.64801,
         "PE_Ratio": 5.24,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 1.16,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "USB": {
         "Symbol": "USB",
@@ -1258,6 +1396,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.579229,
         "PE_Ratio": 12.06,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 1.0,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "PG": {
         "Symbol": "PG",
@@ -1276,6 +1416,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.706906,
         "PE_Ratio": 23.97,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 4.78,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "GE": {
         "Symbol": "GE",
@@ -1294,6 +1436,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.465063,
         "PE_Ratio": 42.9,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 2.13,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "XOM": {
         "Symbol": "XOM",
@@ -1312,6 +1456,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.676927,
         "PE_Ratio": 16.03,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 2.81,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "MDLZ": {
         "Symbol": "MDLZ",
@@ -1330,6 +1476,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.83711,
         "PE_Ratio": 23.34,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 8.28,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "MS": {
         "Symbol": "MS",
@@ -1348,6 +1496,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.555252,
         "PE_Ratio": 18.11,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 1.84,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "HON": {
         "Symbol": "HON",
@@ -1366,6 +1516,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.665022,
         "PE_Ratio": 23.82,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 3.06,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "VZ": {
         "Symbol": "VZ",
@@ -1384,6 +1536,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.763904,
         "PE_Ratio": 10.11,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 2.9,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "PEP": {
         "Symbol": "PEP",
@@ -1402,6 +1556,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.620871,
         "PE_Ratio": 25.82,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 7.74,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "AMD": {
         "Symbol": "AMD",
@@ -1420,6 +1576,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.415663,
         "PE_Ratio": 94.25,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 2.93,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "ZM": {
         "Symbol": "ZM",
@@ -1438,6 +1596,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.468646,
         "PE_Ratio": 22.15,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 5.28,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "BAC": {
         "Symbol": "BAC",
@@ -1456,6 +1616,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.479547,
         "PE_Ratio": 15.32,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 1.02,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "BMY": {
         "Symbol": "BMY",
@@ -1474,6 +1636,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.540563,
         "PE_Ratio": 18.08,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 0.25,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "BKNG": {
         "Symbol": "BKNG",
@@ -1492,6 +1656,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.168853,
         "PE_Ratio": 37.88,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 2.26,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "PFE": {
         "Symbol": "PFE",
@@ -1510,6 +1676,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.443779,
         "PE_Ratio": 12.71,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 106.52,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "QCOM": {
         "Symbol": "QCOM",
@@ -1528,6 +1696,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.50312,
         "PE_Ratio": 16.11,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 1.9,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "GILD": {
         "Symbol": "GILD",
@@ -1546,6 +1716,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.605332,
         "PE_Ratio": 22.64,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 0.85,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "PYPL": {
         "Symbol": "PYPL",
@@ -1564,6 +1736,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.544042,
         "PE_Ratio": 14.61,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 1.17,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "UPS": {
         "Symbol": "UPS",
@@ -1582,6 +1756,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.819558,
         "PE_Ratio": 12.51,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 10.16,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "TEAM": {
         "Symbol": "TEAM",
@@ -1600,6 +1776,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.591834,
         "PE_Ratio": 41.13,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 1.9,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "INTC": {
         "Symbol": "INTC",
@@ -1618,6 +1796,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.3689,
         "PE_Ratio": 30.49,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 0.07,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "C": {
         "Symbol": "C",
@@ -1636,6 +1816,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.239356,
         "PE_Ratio": 15.17,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 0.59,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "MU": {
         "Symbol": "MU",
@@ -1654,6 +1836,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.347573,
         "PE_Ratio": 29.32,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 0.23,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "DDOG": {
         "Symbol": "DDOG",
@@ -1672,6 +1856,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.753746,
         "PE_Ratio": 385.61,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 29.02,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "SNOW": {
         "Symbol": "SNOW",
@@ -1690,6 +1876,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.76019,
         "PE_Ratio": 247.83,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 5.9,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "AAPL": {
         "Symbol": "AAPL",
@@ -1708,6 +1896,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.481752,
         "PE_Ratio": 37.31,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 4.11,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "UNH": {
         "Symbol": "UNH",
@@ -1726,6 +1916,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.555614,
         "PE_Ratio": 14.58,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 1.29,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "NFLX": {
         "Symbol": "NFLX",
@@ -1744,6 +1936,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.621519,
         "PE_Ratio": 52.35,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 2.04,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "TTD": {
         "Symbol": "TTD",
@@ -1762,6 +1956,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.578926,
         "PE_Ratio": 53.58,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 2.84,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "SMCI": {
         "Symbol": "SMCI",
@@ -1780,6 +1976,8 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.388124,
         "PE_Ratio": 27.27,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 1.51,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "ENPH": {
         "Symbol": "ENPH",
@@ -1798,5 +1996,7 @@ A1_SYMBOL_STATS = {
         "Fit_Quality": 0.389706,
         "PE_Ratio": 29.78,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 10.06,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
 }

--- a/a1g_symbol_stats.py
+++ b/a1g_symbol_stats.py
@@ -16,6 +16,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.445459,
         "PE_Ratio": 628.93,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 15.05,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "CRWD": {
         "Symbol": "CRWD",
@@ -34,6 +36,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.712175,
         "PE_Ratio": 117.69,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 7.24,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "SHOP": {
         "Symbol": "SHOP",
@@ -52,6 +56,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.449149,
         "PE_Ratio": 85.64,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 3.67,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "ARM": {
         "Symbol": "ARM",
@@ -70,6 +76,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.764505,
         "PE_Ratio": 216.53,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 10.62,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "NET": {
         "Symbol": "NET",
@@ -88,6 +96,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.549776,
         "PE_Ratio": 262.72,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 10.45,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "AVGO": {
         "Symbol": "AVGO",
@@ -106,6 +116,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.792856,
         "PE_Ratio": 88.45,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 2.63,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "TSLA": {
         "Symbol": "TSLA",
@@ -124,6 +136,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.548662,
         "PE_Ratio": 256.67,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 17.65,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "GOOGL": {
         "Symbol": "GOOGL",
@@ -142,6 +156,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.78531,
         "PE_Ratio": 27.18,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 1.84,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "NVDA": {
         "Symbol": "NVDA",
@@ -160,6 +176,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.385269,
         "PE_Ratio": 50.19,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 1.44,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "MA": {
         "Symbol": "MA",
@@ -178,6 +196,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.819381,
         "PE_Ratio": 39.36,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 2.64,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "NOW": {
         "Symbol": "NOW",
@@ -196,6 +216,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.783125,
         "PE_Ratio": 120.44,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 5.99,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "ADBE": {
         "Symbol": "ADBE",
@@ -214,6 +236,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.637063,
         "PE_Ratio": 22.83,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 1.81,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "NFLX": {
         "Symbol": "NFLX",
@@ -232,6 +256,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.621519,
         "PE_Ratio": 52.35,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 2.04,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "AMZN": {
         "Symbol": "AMZN",
@@ -250,6 +276,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.441889,
         "PE_Ratio": 35.34,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 1.9,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "PANW": {
         "Symbol": "PANW",
@@ -268,6 +296,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.784412,
         "PE_Ratio": 130.12,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 9.69,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "CSCO": {
         "Symbol": "CSCO",
@@ -286,6 +316,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.327551,
         "PE_Ratio": 26.75,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 4.68,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "ASML": {
         "Symbol": "ASML",
@@ -304,6 +336,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.496898,
         "PE_Ratio": 32.79,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 1.73,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "BLK": {
         "Symbol": "BLK",
@@ -322,6 +356,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.771588,
         "PE_Ratio": 27.63,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 2.47,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "MSFT": {
         "Symbol": "MSFT",
@@ -340,6 +376,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.44649,
         "PE_Ratio": 38.03,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 2.28,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "META": {
         "Symbol": "META",
@@ -358,6 +396,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.79007,
         "PE_Ratio": 28.25,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 2.2,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "V": {
         "Symbol": "V",
@@ -376,6 +416,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.846725,
         "PE_Ratio": 33.33,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 2.59,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "CRM": {
         "Symbol": "CRM",
@@ -394,6 +436,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.797486,
         "PE_Ratio": 35.97,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 2.88,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "HD": {
         "Symbol": "HD",
@@ -412,6 +456,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.457783,
         "PE_Ratio": 28.24,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 5.35,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "OKTA": {
         "Symbol": "OKTA",
@@ -430,6 +476,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.49095,
         "PE_Ratio": 111.15,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 8.9,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "DHR": {
         "Symbol": "DHR",
@@ -448,6 +496,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.680363,
         "PE_Ratio": 40.95,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 5.01,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "INTU": {
         "Symbol": "INTU",
@@ -466,6 +516,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.6749,
         "PE_Ratio": 50.25,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 3.45,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "NVO": {
         "Symbol": "NVO",
@@ -484,6 +536,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.626291,
         "PE_Ratio": 15.54,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 1.34,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "DDOG": {
         "Symbol": "DDOG",
@@ -502,6 +556,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.753746,
         "PE_Ratio": 385.61,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 29.02,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "TSM": {
         "Symbol": "TSM",
@@ -520,6 +576,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.524152,
         "PE_Ratio": 28.67,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 1.21,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "TMO": {
         "Symbol": "TMO",
@@ -538,6 +596,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.652472,
         "PE_Ratio": 27.71,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 3.88,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "ISRG": {
         "Symbol": "ISRG",
@@ -556,6 +616,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.626793,
         "PE_Ratio": 61.36,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 4.49,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "MO": {
         "Symbol": "MO",
@@ -574,6 +636,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.665692,
         "PE_Ratio": 12.55,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 2.91,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "ACN": {
         "Symbol": "ACN",
@@ -592,6 +656,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.845391,
         "PE_Ratio": 19.08,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 2.49,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "ORCL": {
         "Symbol": "ORCL",
@@ -610,6 +676,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.414956,
         "PE_Ratio": 71.45,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 3.11,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "SYK": {
         "Symbol": "SYK",
@@ -628,6 +696,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.576481,
         "PE_Ratio": 49.98,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 4.48,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "SBUX": {
         "Symbol": "SBUX",
@@ -646,6 +716,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.735602,
         "PE_Ratio": 36.61,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 110.82,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "MCD": {
         "Symbol": "MCD",
@@ -664,6 +736,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.732731,
         "PE_Ratio": 25.91,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 3.54,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "ABT": {
         "Symbol": "ABT",
@@ -682,6 +756,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.725136,
         "PE_Ratio": 17.07,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 1.65,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "SPGI": {
         "Symbol": "SPGI",
@@ -700,6 +776,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.728385,
         "PE_Ratio": 38.92,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 3.51,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "LIN": {
         "Symbol": "LIN",
@@ -718,6 +796,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.822908,
         "PE_Ratio": 34.02,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 4.15,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "ADP": {
         "Symbol": "ADP",
@@ -736,6 +816,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.687156,
         "PE_Ratio": 29.23,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 3.09,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "AMGN": {
         "Symbol": "AMGN",
@@ -754,6 +836,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.467223,
         "PE_Ratio": 23.32,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 5.59,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "SCHW": {
         "Symbol": "SCHW",
@@ -772,6 +856,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.35699,
         "PE_Ratio": 25.36,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 1.04,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "WMT": {
         "Symbol": "WMT",
@@ -790,6 +876,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.431049,
         "PE_Ratio": 38.62,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 4.12,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "PM": {
         "Symbol": "PM",
@@ -808,6 +896,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.830041,
         "PE_Ratio": 24.11,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 2.62,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "COST": {
         "Symbol": "COST",
@@ -826,6 +916,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.656105,
         "PE_Ratio": 54.04,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 5.27,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "ZTS": {
         "Symbol": "ZTS",
@@ -844,6 +936,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.802914,
         "PE_Ratio": 25.11,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 2.97,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "MMC": {
         "Symbol": "MMC",
@@ -862,6 +956,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.692973,
         "PE_Ratio": 23.65,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 2.71,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "LLY": {
         "Symbol": "LLY",
@@ -880,6 +976,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.556678,
         "PE_Ratio": 49.25,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 1.2,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "GS": {
         "Symbol": "GS",
@@ -898,6 +996,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.758195,
         "PE_Ratio": 17.73,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 1.28,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "NKE": {
         "Symbol": "NKE",
@@ -916,6 +1016,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.662665,
         "PE_Ratio": 32.82,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 3.33,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "DIS": {
         "Symbol": "DIS",
@@ -934,6 +1036,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.569032,
         "PE_Ratio": 17.83,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 1.31,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "DE": {
         "Symbol": "DE",
@@ -952,6 +1056,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.712026,
         "PE_Ratio": 24.51,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 1.73,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "RTX": {
         "Symbol": "RTX",
@@ -970,6 +1076,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.68452,
         "PE_Ratio": 34.7,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 3.77,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "AMAT": {
         "Symbol": "AMAT",
@@ -988,6 +1096,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.350814,
         "PE_Ratio": 22.68,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 3.18,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "TEAM": {
         "Symbol": "TEAM",
@@ -1006,6 +1116,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.591834,
         "PE_Ratio": 41.13,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 1.9,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "SO": {
         "Symbol": "SO",
@@ -1024,6 +1136,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.799691,
         "PE_Ratio": 23.72,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 3.51,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "T": {
         "Symbol": "T",
@@ -1042,6 +1156,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.677408,
         "PE_Ratio": 16.58,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 4.71,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "CB": {
         "Symbol": "CB",
@@ -1060,6 +1176,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.810835,
         "PE_Ratio": 12.09,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 1.64,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "CMCSA": {
         "Symbol": "CMCSA",
@@ -1078,6 +1196,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.64801,
         "PE_Ratio": 5.24,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 1.16,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "MRK": {
         "Symbol": "MRK",
@@ -1096,6 +1216,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.518787,
         "PE_Ratio": 12.56,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 1.13,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "KO": {
         "Symbol": "KO",
@@ -1114,6 +1236,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.529744,
         "PE_Ratio": 23.56,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 3.76,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "QCOM": {
         "Symbol": "QCOM",
@@ -1132,6 +1256,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.50312,
         "PE_Ratio": 16.11,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 1.9,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "AXP": {
         "Symbol": "AXP",
@@ -1150,6 +1276,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.657569,
         "PE_Ratio": 23.99,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 2.06,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "JNJ": {
         "Symbol": "JNJ",
@@ -1168,6 +1296,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.637569,
         "PE_Ratio": 18.86,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 2.85,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "TXN": {
         "Symbol": "TXN",
@@ -1186,6 +1316,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.576156,
         "PE_Ratio": 32.79,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 2.27,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "BA": {
         "Symbol": "BA",
@@ -1204,6 +1336,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.616811,
         "PE_Ratio": 458.83,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 1.91,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "CAT": {
         "Symbol": "CAT",
@@ -1222,6 +1356,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.690914,
         "PE_Ratio": 23.75,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 5.25,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "JPM": {
         "Symbol": "JPM",
@@ -1240,6 +1376,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.698793,
         "PE_Ratio": 16.16,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 2.47,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "IBM": {
         "Symbol": "IBM",
@@ -1258,6 +1396,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.721534,
         "PE_Ratio": 42.9,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 6.04,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "UNH": {
         "Symbol": "UNH",
@@ -1276,6 +1416,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.555614,
         "PE_Ratio": 14.58,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 1.29,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "BK": {
         "Symbol": "BK",
@@ -1294,6 +1436,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.501072,
         "PE_Ratio": 16.62,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 1.14,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "PYPL": {
         "Symbol": "PYPL",
@@ -1312,6 +1456,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.544042,
         "PE_Ratio": 14.61,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 1.17,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "MS": {
         "Symbol": "MS",
@@ -1330,6 +1476,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.555252,
         "PE_Ratio": 18.11,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 1.84,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "PG": {
         "Symbol": "PG",
@@ -1348,6 +1496,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.706906,
         "PE_Ratio": 23.97,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 4.78,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "USB": {
         "Symbol": "USB",
@@ -1366,6 +1516,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.579229,
         "PE_Ratio": 12.06,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 1.0,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "BKNG": {
         "Symbol": "BKNG",
@@ -1384,6 +1536,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.168853,
         "PE_Ratio": 37.88,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 2.26,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "VZ": {
         "Symbol": "VZ",
@@ -1402,6 +1556,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.763904,
         "PE_Ratio": 10.11,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 2.9,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "BAC": {
         "Symbol": "BAC",
@@ -1420,6 +1576,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.479547,
         "PE_Ratio": 15.32,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 1.02,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "MDLZ": {
         "Symbol": "MDLZ",
@@ -1438,6 +1596,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.83711,
         "PE_Ratio": 23.34,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 8.28,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "CHTR": {
         "Symbol": "CHTR",
@@ -1456,6 +1616,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.705278,
         "PE_Ratio": 7.19,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 0.59,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "GE": {
         "Symbol": "GE",
@@ -1474,6 +1636,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.465063,
         "PE_Ratio": 42.9,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 2.13,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "HON": {
         "Symbol": "HON",
@@ -1492,6 +1656,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.665022,
         "PE_Ratio": 23.82,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 3.06,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "PEP": {
         "Symbol": "PEP",
@@ -1510,6 +1676,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.620871,
         "PE_Ratio": 25.82,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 7.74,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "XOM": {
         "Symbol": "XOM",
@@ -1528,6 +1696,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.676927,
         "PE_Ratio": 16.03,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 2.81,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "AMD": {
         "Symbol": "AMD",
@@ -1546,6 +1716,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.415663,
         "PE_Ratio": 94.25,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 2.93,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "LMT": {
         "Symbol": "LMT",
@@ -1564,6 +1736,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.417777,
         "PE_Ratio": 26.52,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 2.18,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "BMY": {
         "Symbol": "BMY",
@@ -1582,6 +1756,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.540563,
         "PE_Ratio": 18.08,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 0.25,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "GILD": {
         "Symbol": "GILD",
@@ -1600,6 +1776,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.605332,
         "PE_Ratio": 22.64,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 0.85,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "INTC": {
         "Symbol": "INTC",
@@ -1618,6 +1796,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.3689,
         "PE_Ratio": 30.49,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 0.07,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "PFE": {
         "Symbol": "PFE",
@@ -1636,6 +1816,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.443779,
         "PE_Ratio": 12.71,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 106.52,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "ZM": {
         "Symbol": "ZM",
@@ -1654,6 +1836,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.468646,
         "PE_Ratio": 22.15,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 5.28,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "UPS": {
         "Symbol": "UPS",
@@ -1672,6 +1856,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.819558,
         "PE_Ratio": 12.51,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 10.16,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "C": {
         "Symbol": "C",
@@ -1690,6 +1876,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.239356,
         "PE_Ratio": 15.17,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 0.59,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "MU": {
         "Symbol": "MU",
@@ -1708,6 +1896,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.347573,
         "PE_Ratio": 29.32,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 0.23,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "SNOW": {
         "Symbol": "SNOW",
@@ -1726,6 +1916,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.76019,
         "PE_Ratio": 247.83,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 5.9,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "ENPH": {
         "Symbol": "ENPH",
@@ -1744,6 +1936,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.389706,
         "PE_Ratio": 29.78,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 10.06,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "AAPL": {
         "Symbol": "AAPL",
@@ -1762,6 +1956,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.481752,
         "PE_Ratio": 37.31,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 4.11,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "TTD": {
         "Symbol": "TTD",
@@ -1780,6 +1976,8 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.578926,
         "PE_Ratio": 53.58,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 2.84,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
     "SMCI": {
         "Symbol": "SMCI",
@@ -1798,5 +1996,7 @@ A1G_SYMBOL_STATS = {
         "Fit_Quality": 0.388124,
         "PE_Ratio": 27.27,
         "PE_Ratio_As_Of": '2025-09-21',
+        "PEG_Ratio": 1.51,
+        "PEG_Ratio_As_Of": '2025-09-21',
     },
 }

--- a/strategy_tqqq_reserve.py
+++ b/strategy_tqqq_reserve.py
@@ -82,8 +82,8 @@ import os
 import re
 from typing import Mapping, Optional, Sequence
 
+from tqqq import ensure_fundamental_ratios
 from tqqq import fetch_fred_series as download_fred_series
-from tqqq import ensure_pe_ratio
 from tqqq import iterative_constant_growth, load_price_csv
 
 
@@ -3088,7 +3088,7 @@ def main():
         # Rebalance count
         rebalance_count = int(len(rebalance_entries))
 
-        pe_ratio = ensure_pe_ratio(symbol_upper, symbol_dir)
+        ratios = ensure_fundamental_ratios(symbol_upper, symbol_dir)
 
         with open(summary_path, "w", encoding="utf-8") as fh:
             fh.write(f"# {symbol_upper} – Strategy {args.experiment} Summary\n\n")
@@ -3098,7 +3098,8 @@ def main():
             fh.write(f"- **Strategy CAGR**: {cagr * 100.0:.2f}%\n")
             fh.write(f"- **Max drawdown**: {max_drawdown * 100.0:.2f}%\n")
             fh.write(f"- **Rebalances executed**: {rebalance_count}\n")
-            fh.write(pe_ratio.as_summary_line() + "\n")
+            fh.write(ratios.pe_ratio.as_summary_line() + "\n")
+            fh.write(ratios.peg_ratio.as_summary_line() + "\n")
             fh.write("\n")
             fh.write("Notes:\n\n")
             fh.write("- Temperatures and anchors per experiment govern deployment; see EXPERIMENTS.md for details.\n")

--- a/symbols/^gspc/fundamentals.json
+++ b/symbols/^gspc/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": null,
+  "peg_ratio": null,
   "source": "yfinance",
   "symbol": "^GSPC"
 }

--- a/symbols/aapl/aapl_A1_summary.md
+++ b/symbols/aapl/aapl_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -16354.24%
 - **Rebalances executed**: 119
 - **P/E ratio (as of 2025-09-21)**: 37.31
+- **PEG ratio (as of 2025-09-21)**: 4.11
 
 Notes:
 

--- a/symbols/aapl/aapl_A1g_summary.md
+++ b/symbols/aapl/aapl_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -19797.23%
 - **Rebalances executed**: 210
 - **P/E ratio (as of 2025-09-21)**: 37.31
+- **PEG ratio (as of 2025-09-21)**: 4.11
 
 Notes:
 

--- a/symbols/aapl/fundamentals.json
+++ b/symbols/aapl/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 37.31003,
+  "peg_ratio": 4.11,
   "source": "yfinance",
   "symbol": "AAPL"
 }

--- a/symbols/abt/abt_A1_summary.md
+++ b/symbols/abt/abt_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -72.72%
 - **Rebalances executed**: 210
 - **P/E ratio (as of 2025-09-21)**: 17.07
+- **PEG ratio (as of 2025-09-21)**: 1.65
 
 Notes:
 

--- a/symbols/abt/abt_A1g_summary.md
+++ b/symbols/abt/abt_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -65.39%
 - **Rebalances executed**: 252
 - **P/E ratio (as of 2025-09-21)**: 17.07
+- **PEG ratio (as of 2025-09-21)**: 1.65
 
 Notes:
 

--- a/symbols/abt/fundamentals.json
+++ b/symbols/abt/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 17.069008,
+  "peg_ratio": 1.65,
   "source": "yfinance",
   "symbol": "ABT"
 }

--- a/symbols/acn/acn_A1_summary.md
+++ b/symbols/acn/acn_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -83.61%
 - **Rebalances executed**: 151
 - **P/E ratio (as of 2025-09-21)**: 19.08
+- **PEG ratio (as of 2025-09-21)**: 2.49
 
 Notes:
 

--- a/symbols/acn/acn_A1g_summary.md
+++ b/symbols/acn/acn_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -76.93%
 - **Rebalances executed**: 137
 - **P/E ratio (as of 2025-09-21)**: 19.08
+- **PEG ratio (as of 2025-09-21)**: 2.49
 
 Notes:
 

--- a/symbols/acn/fundamentals.json
+++ b/symbols/acn/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 19.084394,
+  "peg_ratio": 2.49,
   "source": "yfinance",
   "symbol": "ACN"
 }

--- a/symbols/adbe/adbe_A1_summary.md
+++ b/symbols/adbe/adbe_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -95.73%
 - **Rebalances executed**: 139
 - **P/E ratio (as of 2025-09-21)**: 22.83
+- **PEG ratio (as of 2025-09-21)**: 1.81
 
 Notes:
 

--- a/symbols/adbe/adbe_A1g_summary.md
+++ b/symbols/adbe/adbe_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -90.94%
 - **Rebalances executed**: 176
 - **P/E ratio (as of 2025-09-21)**: 22.83
+- **PEG ratio (as of 2025-09-21)**: 1.81
 
 Notes:
 

--- a/symbols/adbe/fundamentals.json
+++ b/symbols/adbe/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 22.82595,
+  "peg_ratio": 1.81,
   "source": "yfinance",
   "symbol": "ADBE"
 }

--- a/symbols/adp/adp_A1_summary.md
+++ b/symbols/adp/adp_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -84.69%
 - **Rebalances executed**: 190
 - **P/E ratio (as of 2025-09-21)**: 29.23
+- **PEG ratio (as of 2025-09-21)**: 3.09
 
 Notes:
 

--- a/symbols/adp/adp_A1g_summary.md
+++ b/symbols/adp/adp_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -77.63%
 - **Rebalances executed**: 253
 - **P/E ratio (as of 2025-09-21)**: 29.23
+- **PEG ratio (as of 2025-09-21)**: 3.09
 
 Notes:
 

--- a/symbols/adp/fundamentals.json
+++ b/symbols/adp/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 29.229229,
+  "peg_ratio": 3.09,
   "source": "yfinance",
   "symbol": "ADP"
 }

--- a/symbols/amat/amat_A1_summary.md
+++ b/symbols/amat/amat_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -98.84%
 - **Rebalances executed**: 92
 - **P/E ratio (as of 2025-09-21)**: 22.68
+- **PEG ratio (as of 2025-09-21)**: 3.18
 
 Notes:
 

--- a/symbols/amat/amat_A1g_summary.md
+++ b/symbols/amat/amat_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -98.69%
 - **Rebalances executed**: 173
 - **P/E ratio (as of 2025-09-21)**: 22.68
+- **PEG ratio (as of 2025-09-21)**: 3.18
 
 Notes:
 

--- a/symbols/amat/fundamentals.json
+++ b/symbols/amat/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 22.684965,
+  "peg_ratio": 3.18,
   "source": "yfinance",
   "symbol": "AMAT"
 }

--- a/symbols/amd/amd_A1_summary.md
+++ b/symbols/amd/amd_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -100.00%
 - **Rebalances executed**: 125
 - **P/E ratio (as of 2025-09-21)**: 94.25
+- **PEG ratio (as of 2025-09-21)**: 2.93
 
 Notes:
 

--- a/symbols/amd/amd_A1g_summary.md
+++ b/symbols/amd/amd_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -100.00%
 - **Rebalances executed**: 177
 - **P/E ratio (as of 2025-09-21)**: 94.25
+- **PEG ratio (as of 2025-09-21)**: 2.93
 
 Notes:
 

--- a/symbols/amd/fundamentals.json
+++ b/symbols/amd/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 94.245514,
+  "peg_ratio": 2.93,
   "source": "yfinance",
   "symbol": "AMD"
 }

--- a/symbols/amgn/amgn_A1_summary.md
+++ b/symbols/amgn/amgn_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -98.39%
 - **Rebalances executed**: 113
 - **P/E ratio (as of 2025-09-21)**: 23.32
+- **PEG ratio (as of 2025-09-21)**: 5.59
 
 Notes:
 

--- a/symbols/amgn/amgn_A1g_summary.md
+++ b/symbols/amgn/amgn_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -97.06%
 - **Rebalances executed**: 185
 - **P/E ratio (as of 2025-09-21)**: 23.32
+- **PEG ratio (as of 2025-09-21)**: 5.59
 
 Notes:
 

--- a/symbols/amgn/fundamentals.json
+++ b/symbols/amgn/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 23.317812,
+  "peg_ratio": 5.59,
   "source": "yfinance",
   "symbol": "AMGN"
 }

--- a/symbols/amzn/amzn_A1_summary.md
+++ b/symbols/amzn/amzn_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -99.08%
 - **Rebalances executed**: 107
 - **P/E ratio (as of 2025-09-21)**: 35.34
+- **PEG ratio (as of 2025-09-21)**: 1.90
 
 Notes:
 

--- a/symbols/amzn/amzn_A1g_summary.md
+++ b/symbols/amzn/amzn_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -98.41%
 - **Rebalances executed**: 120
 - **P/E ratio (as of 2025-09-21)**: 35.34
+- **PEG ratio (as of 2025-09-21)**: 1.90
 
 Notes:
 

--- a/symbols/amzn/fundamentals.json
+++ b/symbols/amzn/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 35.340458,
+  "peg_ratio": 1.9,
   "source": "yfinance",
   "symbol": "AMZN"
 }

--- a/symbols/arm/arm_A1_summary.md
+++ b/symbols/arm/arm_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -69.15%
 - **Rebalances executed**: 15
 - **P/E ratio (as of 2025-09-21)**: 216.53
+- **PEG ratio (as of 2025-09-21)**: 10.62
 
 Notes:
 

--- a/symbols/arm/arm_A1g_summary.md
+++ b/symbols/arm/arm_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -61.04%
 - **Rebalances executed**: 12
 - **P/E ratio (as of 2025-09-21)**: 216.53
+- **PEG ratio (as of 2025-09-21)**: 10.62
 
 Notes:
 

--- a/symbols/arm/fundamentals.json
+++ b/symbols/arm/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 216.5303,
+  "peg_ratio": 10.62,
   "source": "yfinance",
   "symbol": "ARM"
 }

--- a/symbols/asml/asml_A1_summary.md
+++ b/symbols/asml/asml_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -93.62%
 - **Rebalances executed**: 116
 - **P/E ratio (as of 2025-09-21)**: 32.79
+- **PEG ratio (as of 2025-09-21)**: 1.73
 
 Notes:
 

--- a/symbols/asml/asml_A1g_summary.md
+++ b/symbols/asml/asml_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -94.12%
 - **Rebalances executed**: 141
 - **P/E ratio (as of 2025-09-21)**: 32.79
+- **PEG ratio (as of 2025-09-21)**: 1.73
 
 Notes:
 

--- a/symbols/asml/fundamentals.json
+++ b/symbols/asml/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 32.787548,
+  "peg_ratio": 1.73,
   "source": "yfinance",
   "symbol": "ASML"
 }

--- a/symbols/avgo/avgo_A1_summary.md
+++ b/symbols/avgo/avgo_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -80.20%
 - **Rebalances executed**: 84
 - **P/E ratio (as of 2025-09-21)**: 88.45
+- **PEG ratio (as of 2025-09-21)**: 2.63
 
 Notes:
 

--- a/symbols/avgo/avgo_A1g_summary.md
+++ b/symbols/avgo/avgo_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -79.26%
 - **Rebalances executed**: 93
 - **P/E ratio (as of 2025-09-21)**: 88.45
+- **PEG ratio (as of 2025-09-21)**: 2.63
 
 Notes:
 

--- a/symbols/avgo/fundamentals.json
+++ b/symbols/avgo/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 88.44615,
+  "peg_ratio": 2.63,
   "source": "yfinance",
   "symbol": "AVGO"
 }

--- a/symbols/axp/axp_A1_summary.md
+++ b/symbols/axp/axp_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -97.90%
 - **Rebalances executed**: 208
 - **P/E ratio (as of 2025-09-21)**: 23.99
+- **PEG ratio (as of 2025-09-21)**: 2.06
 
 Notes:
 

--- a/symbols/axp/axp_A1g_summary.md
+++ b/symbols/axp/axp_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -97.44%
 - **Rebalances executed**: 248
 - **P/E ratio (as of 2025-09-21)**: 23.99
+- **PEG ratio (as of 2025-09-21)**: 2.06
 
 Notes:
 

--- a/symbols/axp/fundamentals.json
+++ b/symbols/axp/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 23.988747,
+  "peg_ratio": 2.06,
   "source": "yfinance",
   "symbol": "AXP"
 }

--- a/symbols/ba/ba_A1_summary.md
+++ b/symbols/ba/ba_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -99.69%
 - **Rebalances executed**: 179
 - **P/E ratio (as of 2025-09-21)**: 458.83
+- **PEG ratio (as of 2025-09-21)**: 1.91
 
 Notes:
 

--- a/symbols/ba/ba_A1g_summary.md
+++ b/symbols/ba/ba_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -99.62%
 - **Rebalances executed**: 286
 - **P/E ratio (as of 2025-09-21)**: 458.83
+- **PEG ratio (as of 2025-09-21)**: 1.91
 
 Notes:
 

--- a/symbols/ba/fundamentals.json
+++ b/symbols/ba/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 458.82977,
+  "peg_ratio": 1.908212809315866,
   "source": "yfinance",
   "symbol": "BA"
 }

--- a/symbols/bac/bac_A1_summary.md
+++ b/symbols/bac/bac_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -99.43%
 - **Rebalances executed**: 120
 - **P/E ratio (as of 2025-09-21)**: 15.32
+- **PEG ratio (as of 2025-09-21)**: 1.02
 
 Notes:
 

--- a/symbols/bac/bac_A1g_summary.md
+++ b/symbols/bac/bac_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -98.25%
 - **Rebalances executed**: 210
 - **P/E ratio (as of 2025-09-21)**: 15.32
+- **PEG ratio (as of 2025-09-21)**: 1.02
 
 Notes:
 

--- a/symbols/bac/fundamentals.json
+++ b/symbols/bac/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 15.32258,
+  "peg_ratio": 1.02,
   "source": "yfinance",
   "symbol": "BAC"
 }

--- a/symbols/bk/bk_A1_summary.md
+++ b/symbols/bk/bk_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -89.24%
 - **Rebalances executed**: 188
 - **P/E ratio (as of 2025-09-21)**: 16.62
+- **PEG ratio (as of 2025-09-21)**: 1.14
 
 Notes:
 

--- a/symbols/bk/bk_A1g_summary.md
+++ b/symbols/bk/bk_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -92.41%
 - **Rebalances executed**: 235
 - **P/E ratio (as of 2025-09-21)**: 16.62
+- **PEG ratio (as of 2025-09-21)**: 1.14
 
 Notes:
 

--- a/symbols/bk/fundamentals.json
+++ b/symbols/bk/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 16.622324,
+  "peg_ratio": 1.14,
   "source": "yfinance",
   "symbol": "BK"
 }

--- a/symbols/bkng/bkng_A1_summary.md
+++ b/symbols/bkng/bkng_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -99.99%
 - **Rebalances executed**: 72
 - **P/E ratio (as of 2025-09-21)**: 37.88
+- **PEG ratio (as of 2025-09-21)**: 2.26
 
 Notes:
 

--- a/symbols/bkng/bkng_A1g_summary.md
+++ b/symbols/bkng/bkng_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -99.92%
 - **Rebalances executed**: 101
 - **P/E ratio (as of 2025-09-21)**: 37.88
+- **PEG ratio (as of 2025-09-21)**: 2.26
 
 Notes:
 

--- a/symbols/bkng/fundamentals.json
+++ b/symbols/bkng/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 37.879635,
+  "peg_ratio": 2.26,
   "source": "yfinance",
   "symbol": "BKNG"
 }

--- a/symbols/blk/blk_A1_summary.md
+++ b/symbols/blk/blk_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -78.08%
 - **Rebalances executed**: 129
 - **P/E ratio (as of 2025-09-21)**: 27.63
+- **PEG ratio (as of 2025-09-21)**: 2.47
 
 Notes:
 

--- a/symbols/blk/blk_A1g_summary.md
+++ b/symbols/blk/blk_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -71.94%
 - **Rebalances executed**: 135
 - **P/E ratio (as of 2025-09-21)**: 27.63
+- **PEG ratio (as of 2025-09-21)**: 2.47
 
 Notes:
 

--- a/symbols/blk/fundamentals.json
+++ b/symbols/blk/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 27.625092,
+  "peg_ratio": 2.47,
   "source": "yfinance",
   "symbol": "BLK"
 }

--- a/symbols/bmy/bmy_A1_summary.md
+++ b/symbols/bmy/bmy_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -90.79%
 - **Rebalances executed**: 189
 - **P/E ratio (as of 2025-09-21)**: 18.08
+- **PEG ratio (as of 2025-09-21)**: 0.25
 
 Notes:
 

--- a/symbols/bmy/bmy_A1g_summary.md
+++ b/symbols/bmy/bmy_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -87.24%
 - **Rebalances executed**: 274
 - **P/E ratio (as of 2025-09-21)**: 18.08
+- **PEG ratio (as of 2025-09-21)**: 0.25
 
 Notes:
 

--- a/symbols/bmy/fundamentals.json
+++ b/symbols/bmy/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 18.080322,
+  "peg_ratio": 0.25,
   "source": "yfinance",
   "symbol": "BMY"
 }

--- a/symbols/brk-b/fundamentals.json
+++ b/symbols/brk-b/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 16.889994,
+  "peg_ratio": 24.48,
   "source": "yfinance",
   "symbol": "BRK-B"
 }

--- a/symbols/btc-usd/fundamentals.json
+++ b/symbols/btc-usd/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": null,
+  "peg_ratio": null,
   "source": "yfinance",
   "symbol": "BTC-USD"
 }

--- a/symbols/c/c_A1_summary.md
+++ b/symbols/c/c_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -99.91%
 - **Rebalances executed**: 78
 - **P/E ratio (as of 2025-09-21)**: 15.17
+- **PEG ratio (as of 2025-09-21)**: 0.59
 
 Notes:
 

--- a/symbols/c/c_A1g_summary.md
+++ b/symbols/c/c_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -98.95%
 - **Rebalances executed**: 211
 - **P/E ratio (as of 2025-09-21)**: 15.17
+- **PEG ratio (as of 2025-09-21)**: 0.59
 
 Notes:
 

--- a/symbols/c/fundamentals.json
+++ b/symbols/c/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 15.166913,
+  "peg_ratio": 0.59,
   "source": "yfinance",
   "symbol": "C"
 }

--- a/symbols/cat/cat_A1_summary.md
+++ b/symbols/cat/cat_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -97.49%
 - **Rebalances executed**: 215
 - **P/E ratio (as of 2025-09-21)**: 23.75
+- **PEG ratio (as of 2025-09-21)**: 5.25
 
 Notes:
 

--- a/symbols/cat/cat_A1g_summary.md
+++ b/symbols/cat/cat_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -96.35%
 - **Rebalances executed**: 328
 - **P/E ratio (as of 2025-09-21)**: 23.75
+- **PEG ratio (as of 2025-09-21)**: 5.25
 
 Notes:
 

--- a/symbols/cat/fundamentals.json
+++ b/symbols/cat/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 23.754583,
+  "peg_ratio": 5.25,
   "source": "yfinance",
   "symbol": "CAT"
 }

--- a/symbols/cb/cb_A1_summary.md
+++ b/symbols/cb/cb_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -91.00%
 - **Rebalances executed**: 180
 - **P/E ratio (as of 2025-09-21)**: 12.09
+- **PEG ratio (as of 2025-09-21)**: 1.64
 
 Notes:
 

--- a/symbols/cb/cb_A1g_summary.md
+++ b/symbols/cb/cb_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -91.86%
 - **Rebalances executed**: 176
 - **P/E ratio (as of 2025-09-21)**: 12.09
+- **PEG ratio (as of 2025-09-21)**: 1.64
 
 Notes:
 

--- a/symbols/cb/fundamentals.json
+++ b/symbols/cb/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 12.092275,
+  "peg_ratio": 1.64,
   "source": "yfinance",
   "symbol": "CB"
 }

--- a/symbols/chtr/chtr_A1_summary.md
+++ b/symbols/chtr/chtr_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -97.77%
 - **Rebalances executed**: 49
 - **P/E ratio (as of 2025-09-21)**: 7.19
+- **PEG ratio (as of 2025-09-21)**: 0.59
 
 Notes:
 

--- a/symbols/chtr/chtr_A1g_summary.md
+++ b/symbols/chtr/chtr_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -95.65%
 - **Rebalances executed**: 70
 - **P/E ratio (as of 2025-09-21)**: 7.19
+- **PEG ratio (as of 2025-09-21)**: 0.59
 
 Notes:
 

--- a/symbols/chtr/fundamentals.json
+++ b/symbols/chtr/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 7.189211,
+  "peg_ratio": 0.59,
   "source": "yfinance",
   "symbol": "CHTR"
 }

--- a/symbols/cmcsa/cmcsa_A1_summary.md
+++ b/symbols/cmcsa/cmcsa_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -93.91%
 - **Rebalances executed**: 203
 - **P/E ratio (as of 2025-09-21)**: 5.24
+- **PEG ratio (as of 2025-09-21)**: 1.16
 
 Notes:
 

--- a/symbols/cmcsa/cmcsa_A1g_summary.md
+++ b/symbols/cmcsa/cmcsa_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -96.06%
 - **Rebalances executed**: 243
 - **P/E ratio (as of 2025-09-21)**: 5.24
+- **PEG ratio (as of 2025-09-21)**: 1.16
 
 Notes:
 

--- a/symbols/cmcsa/fundamentals.json
+++ b/symbols/cmcsa/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 5.238806,
+  "peg_ratio": 1.16,
   "source": "yfinance",
   "symbol": "CMCSA"
 }

--- a/symbols/cni/fundamentals.json
+++ b/symbols/cni/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 17.741444,
+  "peg_ratio": 1.96,
   "source": "yfinance",
   "symbol": "CNI"
 }

--- a/symbols/cost/cost_A1_summary.md
+++ b/symbols/cost/cost_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -93.46%
 - **Rebalances executed**: 143
 - **P/E ratio (as of 2025-09-21)**: 54.04
+- **PEG ratio (as of 2025-09-21)**: 5.27
 
 Notes:
 

--- a/symbols/cost/cost_A1g_summary.md
+++ b/symbols/cost/cost_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -89.46%
 - **Rebalances executed**: 183
 - **P/E ratio (as of 2025-09-21)**: 54.04
+- **PEG ratio (as of 2025-09-21)**: 5.27
 
 Notes:
 

--- a/symbols/cost/fundamentals.json
+++ b/symbols/cost/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 54.04318,
+  "peg_ratio": 5.27,
   "source": "yfinance",
   "symbol": "COST"
 }

--- a/symbols/crm/crm_A1_summary.md
+++ b/symbols/crm/crm_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -93.83%
 - **Rebalances executed**: 122
 - **P/E ratio (as of 2025-09-21)**: 35.97
+- **PEG ratio (as of 2025-09-21)**: 2.88
 
 Notes:
 

--- a/symbols/crm/crm_A1g_summary.md
+++ b/symbols/crm/crm_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -87.81%
 - **Rebalances executed**: 117
 - **P/E ratio (as of 2025-09-21)**: 35.97
+- **PEG ratio (as of 2025-09-21)**: 2.88
 
 Notes:
 

--- a/symbols/crm/fundamentals.json
+++ b/symbols/crm/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 35.966522,
+  "peg_ratio": 2.88,
   "source": "yfinance",
   "symbol": "CRM"
 }

--- a/symbols/crwd/crwd_A1_summary.md
+++ b/symbols/crwd/crwd_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -97.30%
 - **Rebalances executed**: 30
 - **P/E ratio (as of 2025-09-21)**: 117.69
+- **PEG ratio (as of 2025-09-21)**: 7.24
 
 Notes:
 

--- a/symbols/crwd/crwd_A1g_summary.md
+++ b/symbols/crwd/crwd_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -89.56%
 - **Rebalances executed**: 31
 - **P/E ratio (as of 2025-09-21)**: 117.69
+- **PEG ratio (as of 2025-09-21)**: 7.24
 
 Notes:
 

--- a/symbols/crwd/fundamentals.json
+++ b/symbols/crwd/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 117.69321,
+  "peg_ratio": 7.2382047970479695,
   "source": "yfinance",
   "symbol": "CRWD"
 }

--- a/symbols/csco/csco_A1_summary.md
+++ b/symbols/csco/csco_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -93.09%
 - **Rebalances executed**: 105
 - **P/E ratio (as of 2025-09-21)**: 26.75
+- **PEG ratio (as of 2025-09-21)**: 4.68
 
 Notes:
 

--- a/symbols/csco/csco_A1g_summary.md
+++ b/symbols/csco/csco_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -91.78%
 - **Rebalances executed**: 140
 - **P/E ratio (as of 2025-09-21)**: 26.75
+- **PEG ratio (as of 2025-09-21)**: 4.68
 
 Notes:
 

--- a/symbols/csco/fundamentals.json
+++ b/symbols/csco/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 26.74902,
+  "peg_ratio": 4.68,
   "source": "yfinance",
   "symbol": "CSCO"
 }

--- a/symbols/ddog/ddog_A1_summary.md
+++ b/symbols/ddog/ddog_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -95.47%
 - **Rebalances executed**: 42
 - **P/E ratio (as of 2025-09-21)**: 385.61
+- **PEG ratio (as of 2025-09-21)**: 29.02
 
 Notes:
 

--- a/symbols/ddog/ddog_A1g_summary.md
+++ b/symbols/ddog/ddog_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -90.16%
 - **Rebalances executed**: 37
 - **P/E ratio (as of 2025-09-21)**: 385.61
+- **PEG ratio (as of 2025-09-21)**: 29.02
 
 Notes:
 

--- a/symbols/ddog/fundamentals.json
+++ b/symbols/ddog/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 385.6111,
+  "peg_ratio": 29.02,
   "source": "yfinance",
   "symbol": "DDOG"
 }

--- a/symbols/de/de_A1_summary.md
+++ b/symbols/de/de_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -94.54%
 - **Rebalances executed**: 208
 - **P/E ratio (as of 2025-09-21)**: 24.51
+- **PEG ratio (as of 2025-09-21)**: 1.73
 
 Notes:
 

--- a/symbols/de/de_A1g_summary.md
+++ b/symbols/de/de_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -92.02%
 - **Rebalances executed**: 250
 - **P/E ratio (as of 2025-09-21)**: 24.51
+- **PEG ratio (as of 2025-09-21)**: 1.73
 
 Notes:
 

--- a/symbols/de/fundamentals.json
+++ b/symbols/de/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 24.510962,
+  "peg_ratio": 1.733448392259661,
   "source": "yfinance",
   "symbol": "DE"
 }

--- a/symbols/dhr/dhr_A1_summary.md
+++ b/symbols/dhr/dhr_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -89.33%
 - **Rebalances executed**: 146
 - **P/E ratio (as of 2025-09-21)**: 40.95
+- **PEG ratio (as of 2025-09-21)**: 5.01
 
 Notes:
 

--- a/symbols/dhr/dhr_A1g_summary.md
+++ b/symbols/dhr/dhr_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -76.20%
 - **Rebalances executed**: 238
 - **P/E ratio (as of 2025-09-21)**: 40.95
+- **PEG ratio (as of 2025-09-21)**: 5.01
 
 Notes:
 

--- a/symbols/dhr/fundamentals.json
+++ b/symbols/dhr/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 40.95127,
+  "peg_ratio": 5.01,
   "source": "yfinance",
   "symbol": "DHR"
 }

--- a/symbols/dis/dis_A1_summary.md
+++ b/symbols/dis/dis_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -97.36%
 - **Rebalances executed**: 171
 - **P/E ratio (as of 2025-09-21)**: 17.83
+- **PEG ratio (as of 2025-09-21)**: 1.31
 
 Notes:
 

--- a/symbols/dis/dis_A1g_summary.md
+++ b/symbols/dis/dis_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -95.07%
 - **Rebalances executed**: 276
 - **P/E ratio (as of 2025-09-21)**: 17.83
+- **PEG ratio (as of 2025-09-21)**: 1.31
 
 Notes:
 

--- a/symbols/dis/fundamentals.json
+++ b/symbols/dis/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 17.83072,
+  "peg_ratio": 1.31,
   "source": "yfinance",
   "symbol": "DIS"
 }

--- a/symbols/eem/fundamentals.json
+++ b/symbols/eem/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 15.570922,
+  "peg_ratio": null,
   "source": "yfinance",
   "symbol": "EEM"
 }

--- a/symbols/enph/enph_A1_summary.md
+++ b/symbols/enph/enph_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -101.67%
 - **Rebalances executed**: 19
 - **P/E ratio (as of 2025-09-21)**: 29.78
+- **PEG ratio (as of 2025-09-21)**: 10.06
 
 Notes:
 

--- a/symbols/enph/enph_A1g_summary.md
+++ b/symbols/enph/enph_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -99.99%
 - **Rebalances executed**: 42
 - **P/E ratio (as of 2025-09-21)**: 29.78
+- **PEG ratio (as of 2025-09-21)**: 10.06
 
 Notes:
 

--- a/symbols/enph/fundamentals.json
+++ b/symbols/enph/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 29.782946,
+  "peg_ratio": 10.06,
   "source": "yfinance",
   "symbol": "ENPH"
 }

--- a/symbols/eth-usd/fundamentals.json
+++ b/symbols/eth-usd/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": null,
+  "peg_ratio": null,
   "source": "yfinance",
   "symbol": "ETH-USD"
 }

--- a/symbols/ge/fundamentals.json
+++ b/symbols/ge/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 42.897438,
+  "peg_ratio": 2.13,
   "source": "yfinance",
   "symbol": "GE"
 }

--- a/symbols/ge/ge_A1_summary.md
+++ b/symbols/ge/ge_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -99.83%
 - **Rebalances executed**: 216
 - **P/E ratio (as of 2025-09-21)**: 42.90
+- **PEG ratio (as of 2025-09-21)**: 2.13
 
 Notes:
 

--- a/symbols/ge/ge_A1g_summary.md
+++ b/symbols/ge/ge_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -99.51%
 - **Rebalances executed**: 298
 - **P/E ratio (as of 2025-09-21)**: 42.90
+- **PEG ratio (as of 2025-09-21)**: 2.13
 
 Notes:
 

--- a/symbols/gild/fundamentals.json
+++ b/symbols/gild/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 22.636904,
+  "peg_ratio": 0.85,
   "source": "yfinance",
   "symbol": "GILD"
 }

--- a/symbols/gild/gild_A1_summary.md
+++ b/symbols/gild/gild_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -99.74%
 - **Rebalances executed**: 98
 - **P/E ratio (as of 2025-09-21)**: 22.64
+- **PEG ratio (as of 2025-09-21)**: 0.85
 
 Notes:
 

--- a/symbols/gild/gild_A1g_summary.md
+++ b/symbols/gild/gild_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -99.06%
 - **Rebalances executed**: 143
 - **P/E ratio (as of 2025-09-21)**: 22.64
+- **PEG ratio (as of 2025-09-21)**: 0.85
 
 Notes:
 

--- a/symbols/googl/fundamentals.json
+++ b/symbols/googl/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 27.184631,
+  "peg_ratio": 1.84,
   "source": "yfinance",
   "symbol": "GOOGL"
 }

--- a/symbols/googl/googl_A1_summary.md
+++ b/symbols/googl/googl_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -68.02%
 - **Rebalances executed**: 103
 - **P/E ratio (as of 2025-09-21)**: 27.18
+- **PEG ratio (as of 2025-09-21)**: 1.84
 
 Notes:
 

--- a/symbols/googl/googl_A1g_summary.md
+++ b/symbols/googl/googl_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -65.27%
 - **Rebalances executed**: 105
 - **P/E ratio (as of 2025-09-21)**: 27.18
+- **PEG ratio (as of 2025-09-21)**: 1.84
 
 Notes:
 

--- a/symbols/gs/fundamentals.json
+++ b/symbols/gs/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 17.731277,
+  "peg_ratio": 1.28,
   "source": "yfinance",
   "symbol": "GS"
 }

--- a/symbols/gs/gs_A1_summary.md
+++ b/symbols/gs/gs_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -89.72%
 - **Rebalances executed**: 126
 - **P/E ratio (as of 2025-09-21)**: 17.73
+- **PEG ratio (as of 2025-09-21)**: 1.28
 
 Notes:
 

--- a/symbols/gs/gs_A1g_summary.md
+++ b/symbols/gs/gs_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -85.75%
 - **Rebalances executed**: 131
 - **P/E ratio (as of 2025-09-21)**: 17.73
+- **PEG ratio (as of 2025-09-21)**: 1.28
 
 Notes:
 

--- a/symbols/hd/fundamentals.json
+++ b/symbols/hd/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 28.239809,
+  "peg_ratio": 5.35,
   "source": "yfinance",
   "symbol": "HD"
 }

--- a/symbols/hd/hd_A1_summary.md
+++ b/symbols/hd/hd_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -98.66%
 - **Rebalances executed**: 130
 - **P/E ratio (as of 2025-09-21)**: 28.24
+- **PEG ratio (as of 2025-09-21)**: 5.35
 
 Notes:
 

--- a/symbols/hd/hd_A1g_summary.md
+++ b/symbols/hd/hd_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -96.21%
 - **Rebalances executed**: 176
 - **P/E ratio (as of 2025-09-21)**: 28.24
+- **PEG ratio (as of 2025-09-21)**: 5.35
 
 Notes:
 

--- a/symbols/hon/fundamentals.json
+++ b/symbols/hon/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 23.819113,
+  "peg_ratio": 3.06,
   "source": "yfinance",
   "symbol": "HON"
 }

--- a/symbols/hon/hon_A1_summary.md
+++ b/symbols/hon/hon_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -97.76%
 - **Rebalances executed**: 255
 - **P/E ratio (as of 2025-09-21)**: 23.82
+- **PEG ratio (as of 2025-09-21)**: 3.06
 
 Notes:
 

--- a/symbols/hon/hon_A1g_summary.md
+++ b/symbols/hon/hon_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -95.78%
 - **Rebalances executed**: 307
 - **P/E ratio (as of 2025-09-21)**: 23.82
+- **PEG ratio (as of 2025-09-21)**: 3.06
 
 Notes:
 

--- a/symbols/ibm/fundamentals.json
+++ b/symbols/ibm/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 42.89855,
+  "peg_ratio": 6.04,
   "source": "yfinance",
   "symbol": "IBM"
 }

--- a/symbols/ibm/ibm_A1_summary.md
+++ b/symbols/ibm/ibm_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -98.67%
 - **Rebalances executed**: 259
 - **P/E ratio (as of 2025-09-21)**: 42.90
+- **PEG ratio (as of 2025-09-21)**: 6.04
 
 Notes:
 

--- a/symbols/ibm/ibm_A1g_summary.md
+++ b/symbols/ibm/ibm_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -96.73%
 - **Rebalances executed**: 337
 - **P/E ratio (as of 2025-09-21)**: 42.90
+- **PEG ratio (as of 2025-09-21)**: 6.04
 
 Notes:
 

--- a/symbols/intc/fundamentals.json
+++ b/symbols/intc/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 30.494844,
+  "peg_ratio": 0.06789607392367307,
   "source": "yfinance",
   "symbol": "INTC"
 }

--- a/symbols/intc/intc_A1_summary.md
+++ b/symbols/intc/intc_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -99.97%
 - **Rebalances executed**: 145
 - **P/E ratio (as of 2025-09-21)**: 30.49
+- **PEG ratio (as of 2025-09-21)**: 0.07
 
 Notes:
 

--- a/symbols/intc/intc_A1g_summary.md
+++ b/symbols/intc/intc_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -99.63%
 - **Rebalances executed**: 201
 - **P/E ratio (as of 2025-09-21)**: 30.49
+- **PEG ratio (as of 2025-09-21)**: 0.07
 
 Notes:
 

--- a/symbols/intu/fundamentals.json
+++ b/symbols/intu/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 50.249817,
+  "peg_ratio": 3.45,
   "source": "yfinance",
   "symbol": "INTU"
 }

--- a/symbols/intu/intu_A1_summary.md
+++ b/symbols/intu/intu_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -88.54%
 - **Rebalances executed**: 113
 - **P/E ratio (as of 2025-09-21)**: 50.25
+- **PEG ratio (as of 2025-09-21)**: 3.45
 
 Notes:
 

--- a/symbols/intu/intu_A1g_summary.md
+++ b/symbols/intu/intu_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -87.04%
 - **Rebalances executed**: 164
 - **P/E ratio (as of 2025-09-21)**: 50.25
+- **PEG ratio (as of 2025-09-21)**: 3.45
 
 Notes:
 

--- a/symbols/isrg/fundamentals.json
+++ b/symbols/isrg/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 61.35944,
+  "peg_ratio": 4.49,
   "source": "yfinance",
   "symbol": "ISRG"
 }

--- a/symbols/isrg/isrg_A1_summary.md
+++ b/symbols/isrg/isrg_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -99.90%
 - **Rebalances executed**: 95
 - **P/E ratio (as of 2025-09-21)**: 61.36
+- **PEG ratio (as of 2025-09-21)**: 4.49
 
 Notes:
 

--- a/symbols/isrg/isrg_A1g_summary.md
+++ b/symbols/isrg/isrg_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -99.64%
 - **Rebalances executed**: 116
 - **P/E ratio (as of 2025-09-21)**: 61.36
+- **PEG ratio (as of 2025-09-21)**: 4.49
 
 Notes:
 

--- a/symbols/iwm/fundamentals.json
+++ b/symbols/iwm/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 18.702032,
+  "peg_ratio": null,
   "source": "yfinance",
   "symbol": "IWM"
 }

--- a/symbols/jnj/fundamentals.json
+++ b/symbols/jnj/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 18.864025,
+  "peg_ratio": 2.85,
   "source": "yfinance",
   "symbol": "JNJ"
 }

--- a/symbols/jnj/jnj_A1_summary.md
+++ b/symbols/jnj/jnj_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -95.04%
 - **Rebalances executed**: 236
 - **P/E ratio (as of 2025-09-21)**: 18.86
+- **PEG ratio (as of 2025-09-21)**: 2.85
 
 Notes:
 

--- a/symbols/jnj/jnj_A1g_summary.md
+++ b/symbols/jnj/jnj_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -90.40%
 - **Rebalances executed**: 301
 - **P/E ratio (as of 2025-09-21)**: 18.86
+- **PEG ratio (as of 2025-09-21)**: 2.85
 
 Notes:
 

--- a/symbols/jpm/fundamentals.json
+++ b/symbols/jpm/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 16.159138,
+  "peg_ratio": 2.47,
   "source": "yfinance",
   "symbol": "JPM"
 }

--- a/symbols/jpm/jpm_A1_summary.md
+++ b/symbols/jpm/jpm_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -99.05%
 - **Rebalances executed**: 186
 - **P/E ratio (as of 2025-09-21)**: 16.16
+- **PEG ratio (as of 2025-09-21)**: 2.47
 
 Notes:
 

--- a/symbols/jpm/jpm_A1g_summary.md
+++ b/symbols/jpm/jpm_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -98.02%
 - **Rebalances executed**: 227
 - **P/E ratio (as of 2025-09-21)**: 16.16
+- **PEG ratio (as of 2025-09-21)**: 2.47
 
 Notes:
 

--- a/symbols/ko/fundamentals.json
+++ b/symbols/ko/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 23.556738,
+  "peg_ratio": 3.76,
   "source": "yfinance",
   "symbol": "KO"
 }

--- a/symbols/ko/ko_A1_summary.md
+++ b/symbols/ko/ko_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -83.89%
 - **Rebalances executed**: 202
 - **P/E ratio (as of 2025-09-21)**: 23.56
+- **PEG ratio (as of 2025-09-21)**: 3.76
 
 Notes:
 

--- a/symbols/ko/ko_A1g_summary.md
+++ b/symbols/ko/ko_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -77.71%
 - **Rebalances executed**: 312
 - **P/E ratio (as of 2025-09-21)**: 23.56
+- **PEG ratio (as of 2025-09-21)**: 3.76
 
 Notes:
 

--- a/symbols/lin/fundamentals.json
+++ b/symbols/lin/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 34.0206,
+  "peg_ratio": 4.15,
   "source": "yfinance",
   "symbol": "LIN"
 }

--- a/symbols/lin/lin_A1_summary.md
+++ b/symbols/lin/lin_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -89.24%
 - **Rebalances executed**: 182
 - **P/E ratio (as of 2025-09-21)**: 34.02
+- **PEG ratio (as of 2025-09-21)**: 4.15
 
 Notes:
 

--- a/symbols/lin/lin_A1g_summary.md
+++ b/symbols/lin/lin_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -84.15%
 - **Rebalances executed**: 200
 - **P/E ratio (as of 2025-09-21)**: 34.02
+- **PEG ratio (as of 2025-09-21)**: 4.15
 
 Notes:
 

--- a/symbols/lly/fundamentals.json
+++ b/symbols/lly/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 49.24623,
+  "peg_ratio": 1.2,
   "source": "yfinance",
   "symbol": "LLY"
 }

--- a/symbols/lly/lly_A1_summary.md
+++ b/symbols/lly/lly_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -94.36%
 - **Rebalances executed**: 126
 - **P/E ratio (as of 2025-09-21)**: 49.25
+- **PEG ratio (as of 2025-09-21)**: 1.20
 
 Notes:
 

--- a/symbols/lly/lly_A1g_summary.md
+++ b/symbols/lly/lly_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -91.06%
 - **Rebalances executed**: 243
 - **P/E ratio (as of 2025-09-21)**: 49.25
+- **PEG ratio (as of 2025-09-21)**: 1.20
 
 Notes:
 

--- a/symbols/lmt/fundamentals.json
+++ b/symbols/lmt/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 26.524958,
+  "peg_ratio": 2.18,
   "source": "yfinance",
   "symbol": "LMT"
 }

--- a/symbols/lmt/lmt_A1_summary.md
+++ b/symbols/lmt/lmt_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -99.76%
 - **Rebalances executed**: 210
 - **P/E ratio (as of 2025-09-21)**: 26.52
+- **PEG ratio (as of 2025-09-21)**: 2.18
 
 Notes:
 

--- a/symbols/lmt/lmt_A1g_summary.md
+++ b/symbols/lmt/lmt_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -99.88%
 - **Rebalances executed**: 296
 - **P/E ratio (as of 2025-09-21)**: 26.52
+- **PEG ratio (as of 2025-09-21)**: 2.18
 
 Notes:
 

--- a/symbols/ma/fundamentals.json
+++ b/symbols/ma/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 39.36388,
+  "peg_ratio": 2.64,
   "source": "yfinance",
   "symbol": "MA"
 }

--- a/symbols/ma/ma_A1_summary.md
+++ b/symbols/ma/ma_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -83.90%
 - **Rebalances executed**: 88
 - **P/E ratio (as of 2025-09-21)**: 39.36
+- **PEG ratio (as of 2025-09-21)**: 2.64
 
 Notes:
 

--- a/symbols/ma/ma_A1g_summary.md
+++ b/symbols/ma/ma_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -79.01%
 - **Rebalances executed**: 110
 - **P/E ratio (as of 2025-09-21)**: 39.36
+- **PEG ratio (as of 2025-09-21)**: 2.64
 
 Notes:
 

--- a/symbols/mcd/fundamentals.json
+++ b/symbols/mcd/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 25.910883,
+  "peg_ratio": 3.54,
   "source": "yfinance",
   "symbol": "MCD"
 }

--- a/symbols/mcd/mcd_A1_summary.md
+++ b/symbols/mcd/mcd_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -102.39%
 - **Rebalances executed**: 264
 - **P/E ratio (as of 2025-09-21)**: 25.91
+- **PEG ratio (as of 2025-09-21)**: 3.54
 
 Notes:
 

--- a/symbols/mcd/mcd_A1g_summary.md
+++ b/symbols/mcd/mcd_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -92.49%
 - **Rebalances executed**: 295
 - **P/E ratio (as of 2025-09-21)**: 25.91
+- **PEG ratio (as of 2025-09-21)**: 3.54
 
 Notes:
 

--- a/symbols/mdlz/fundamentals.json
+++ b/symbols/mdlz/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 23.336996,
+  "peg_ratio": 8.28,
   "source": "yfinance",
   "symbol": "MDLZ"
 }

--- a/symbols/mdlz/mdlz_A1_summary.md
+++ b/symbols/mdlz/mdlz_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -86.68%
 - **Rebalances executed**: 116
 - **P/E ratio (as of 2025-09-21)**: 23.34
+- **PEG ratio (as of 2025-09-21)**: 8.28
 
 Notes:
 

--- a/symbols/mdlz/mdlz_A1g_summary.md
+++ b/symbols/mdlz/mdlz_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -81.62%
 - **Rebalances executed**: 145
 - **P/E ratio (as of 2025-09-21)**: 23.34
+- **PEG ratio (as of 2025-09-21)**: 8.28
 
 Notes:
 

--- a/symbols/meta/fundamentals.json
+++ b/symbols/meta/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 28.253359,
+  "peg_ratio": 2.2,
   "source": "yfinance",
   "symbol": "META"
 }

--- a/symbols/meta/meta_A1_summary.md
+++ b/symbols/meta/meta_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -99.00%
 - **Rebalances executed**: 67
 - **P/E ratio (as of 2025-09-21)**: 28.25
+- **PEG ratio (as of 2025-09-21)**: 2.20
 
 Notes:
 

--- a/symbols/meta/meta_A1g_summary.md
+++ b/symbols/meta/meta_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -98.02%
 - **Rebalances executed**: 74
 - **P/E ratio (as of 2025-09-21)**: 28.25
+- **PEG ratio (as of 2025-09-21)**: 2.20
 
 Notes:
 

--- a/symbols/mmc/fundamentals.json
+++ b/symbols/mmc/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 23.651443,
+  "peg_ratio": 2.71,
   "source": "yfinance",
   "symbol": "MMC"
 }

--- a/symbols/mmc/mmc_A1_summary.md
+++ b/symbols/mmc/mmc_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -91.18%
 - **Rebalances executed**: 207
 - **P/E ratio (as of 2025-09-21)**: 23.65
+- **PEG ratio (as of 2025-09-21)**: 2.71
 
 Notes:
 

--- a/symbols/mmc/mmc_A1g_summary.md
+++ b/symbols/mmc/mmc_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -92.55%
 - **Rebalances executed**: 289
 - **P/E ratio (as of 2025-09-21)**: 23.65
+- **PEG ratio (as of 2025-09-21)**: 2.71
 
 Notes:
 

--- a/symbols/mo/fundamentals.json
+++ b/symbols/mo/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 12.551257,
+  "peg_ratio": 2.91,
   "source": "yfinance",
   "symbol": "MO"
 }

--- a/symbols/mo/mo_A1_summary.md
+++ b/symbols/mo/mo_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -94.46%
 - **Rebalances executed**: 259
 - **P/E ratio (as of 2025-09-21)**: 12.55
+- **PEG ratio (as of 2025-09-21)**: 2.91
 
 Notes:
 

--- a/symbols/mo/mo_A1g_summary.md
+++ b/symbols/mo/mo_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -89.67%
 - **Rebalances executed**: 320
 - **P/E ratio (as of 2025-09-21)**: 12.55
+- **PEG ratio (as of 2025-09-21)**: 2.91
 
 Notes:
 

--- a/symbols/mrk/fundamentals.json
+++ b/symbols/mrk/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 12.559322,
+  "peg_ratio": 1.13,
   "source": "yfinance",
   "symbol": "MRK"
 }

--- a/symbols/mrk/mrk_A1_summary.md
+++ b/symbols/mrk/mrk_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -89.58%
 - **Rebalances executed**: 201
 - **P/E ratio (as of 2025-09-21)**: 12.56
+- **PEG ratio (as of 2025-09-21)**: 1.13
 
 Notes:
 

--- a/symbols/mrk/mrk_A1g_summary.md
+++ b/symbols/mrk/mrk_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -85.57%
 - **Rebalances executed**: 312
 - **P/E ratio (as of 2025-09-21)**: 12.56
+- **PEG ratio (as of 2025-09-21)**: 1.13
 
 Notes:
 

--- a/symbols/ms/fundamentals.json
+++ b/symbols/ms/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 18.109854,
+  "peg_ratio": 1.84,
   "source": "yfinance",
   "symbol": "MS"
 }

--- a/symbols/ms/ms_A1_summary.md
+++ b/symbols/ms/ms_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -98.65%
 - **Rebalances executed**: 55
 - **P/E ratio (as of 2025-09-21)**: 18.11
+- **PEG ratio (as of 2025-09-21)**: 1.84
 
 Notes:
 

--- a/symbols/ms/ms_A1g_summary.md
+++ b/symbols/ms/ms_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -97.96%
 - **Rebalances executed**: 128
 - **P/E ratio (as of 2025-09-21)**: 18.11
+- **PEG ratio (as of 2025-09-21)**: 1.84
 
 Notes:
 

--- a/symbols/msft/fundamentals.json
+++ b/symbols/msft/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 38.027164,
+  "peg_ratio": 2.28,
   "source": "yfinance",
   "symbol": "MSFT"
 }

--- a/symbols/msft/msft_A1_summary.md
+++ b/symbols/msft/msft_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -98.73%
 - **Rebalances executed**: 98
 - **P/E ratio (as of 2025-09-21)**: 38.03
+- **PEG ratio (as of 2025-09-21)**: 2.28
 
 Notes:
 

--- a/symbols/msft/msft_A1g_summary.md
+++ b/symbols/msft/msft_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -97.05%
 - **Rebalances executed**: 182
 - **P/E ratio (as of 2025-09-21)**: 38.03
+- **PEG ratio (as of 2025-09-21)**: 2.28
 
 Notes:
 

--- a/symbols/mu/fundamentals.json
+++ b/symbols/mu/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 29.320719,
+  "peg_ratio": 0.23,
   "source": "yfinance",
   "symbol": "MU"
 }

--- a/symbols/mu/mu_A1_summary.md
+++ b/symbols/mu/mu_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -100.00%
 - **Rebalances executed**: 146
 - **P/E ratio (as of 2025-09-21)**: 29.32
+- **PEG ratio (as of 2025-09-21)**: 0.23
 
 Notes:
 

--- a/symbols/mu/mu_A1g_summary.md
+++ b/symbols/mu/mu_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -99.99%
 - **Rebalances executed**: 164
 - **P/E ratio (as of 2025-09-21)**: 29.32
+- **PEG ratio (as of 2025-09-21)**: 0.23
 
 Notes:
 

--- a/symbols/net/fundamentals.json
+++ b/symbols/net/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 262.72092,
+  "peg_ratio": 10.450315035799521,
   "source": "yfinance",
   "symbol": "NET"
 }

--- a/symbols/net/net_A1_summary.md
+++ b/symbols/net/net_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -96.74%
 - **Rebalances executed**: 28
 - **P/E ratio (as of 2025-09-21)**: 262.72
+- **PEG ratio (as of 2025-09-21)**: 10.45
 
 Notes:
 

--- a/symbols/net/net_A1g_summary.md
+++ b/symbols/net/net_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -93.73%
 - **Rebalances executed**: 29
 - **P/E ratio (as of 2025-09-21)**: 262.72
+- **PEG ratio (as of 2025-09-21)**: 10.45
 
 Notes:
 

--- a/symbols/nflx/fundamentals.json
+++ b/symbols/nflx/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 52.345135,
+  "peg_ratio": 2.04,
   "source": "yfinance",
   "symbol": "NFLX"
 }

--- a/symbols/nflx/nflx_A1_summary.md
+++ b/symbols/nflx/nflx_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -177.74%
 - **Rebalances executed**: 73
 - **P/E ratio (as of 2025-09-21)**: 52.35
+- **PEG ratio (as of 2025-09-21)**: 2.04
 
 Notes:
 

--- a/symbols/nflx/nflx_A1g_summary.md
+++ b/symbols/nflx/nflx_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -95.85%
 - **Rebalances executed**: 107
 - **P/E ratio (as of 2025-09-21)**: 52.35
+- **PEG ratio (as of 2025-09-21)**: 2.04
 
 Notes:
 

--- a/symbols/nke/fundamentals.json
+++ b/symbols/nke/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 32.819443,
+  "peg_ratio": 3.33,
   "source": "yfinance",
   "symbol": "NKE"
 }

--- a/symbols/nke/nke_A1_summary.md
+++ b/symbols/nke/nke_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -98.83%
 - **Rebalances executed**: 197
 - **P/E ratio (as of 2025-09-21)**: 32.82
+- **PEG ratio (as of 2025-09-21)**: 3.33
 
 Notes:
 

--- a/symbols/nke/nke_A1g_summary.md
+++ b/symbols/nke/nke_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -97.46%
 - **Rebalances executed**: 229
 - **P/E ratio (as of 2025-09-21)**: 32.82
+- **PEG ratio (as of 2025-09-21)**: 3.33
 
 Notes:
 

--- a/symbols/now/fundamentals.json
+++ b/symbols/now/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 120.44486,
+  "peg_ratio": 5.99,
   "source": "yfinance",
   "symbol": "NOW"
 }

--- a/symbols/now/now_A1_summary.md
+++ b/symbols/now/now_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -78.16%
 - **Rebalances executed**: 59
 - **P/E ratio (as of 2025-09-21)**: 120.44
+- **PEG ratio (as of 2025-09-21)**: 5.99
 
 Notes:
 

--- a/symbols/now/now_A1g_summary.md
+++ b/symbols/now/now_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -70.75%
 - **Rebalances executed**: 72
 - **P/E ratio (as of 2025-09-21)**: 120.44
+- **PEG ratio (as of 2025-09-21)**: 5.99
 
 Notes:
 

--- a/symbols/nvda/fundamentals.json
+++ b/symbols/nvda/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 50.190342,
+  "peg_ratio": 1.44,
   "source": "yfinance",
   "symbol": "NVDA"
 }

--- a/symbols/nvda/nvda_A1_summary.md
+++ b/symbols/nvda/nvda_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -99.20%
 - **Rebalances executed**: 82
 - **P/E ratio (as of 2025-09-21)**: 50.19
+- **PEG ratio (as of 2025-09-21)**: 1.44
 
 Notes:
 

--- a/symbols/nvda/nvda_A1g_summary.md
+++ b/symbols/nvda/nvda_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -97.23%
 - **Rebalances executed**: 109
 - **P/E ratio (as of 2025-09-21)**: 50.19
+- **PEG ratio (as of 2025-09-21)**: 1.44
 
 Notes:
 

--- a/symbols/nvo/fundamentals.json
+++ b/symbols/nvo/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 15.544304,
+  "peg_ratio": 1.34,
   "source": "yfinance",
   "symbol": "NVO"
 }

--- a/symbols/nvo/nvo_A1_summary.md
+++ b/symbols/nvo/nvo_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -94.55%
 - **Rebalances executed**: 195
 - **P/E ratio (as of 2025-09-21)**: 15.54
+- **PEG ratio (as of 2025-09-21)**: 1.34
 
 Notes:
 

--- a/symbols/nvo/nvo_A1g_summary.md
+++ b/symbols/nvo/nvo_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -89.28%
 - **Rebalances executed**: 212
 - **P/E ratio (as of 2025-09-21)**: 15.54
+- **PEG ratio (as of 2025-09-21)**: 1.34
 
 Notes:
 

--- a/symbols/okta/fundamentals.json
+++ b/symbols/okta/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 111.15477,
+  "peg_ratio": 8.9,
   "source": "yfinance",
   "symbol": "OKTA"
 }

--- a/symbols/okta/okta_A1_summary.md
+++ b/symbols/okta/okta_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -84.10%
 - **Rebalances executed**: 31
 - **P/E ratio (as of 2025-09-21)**: 111.15
+- **PEG ratio (as of 2025-09-21)**: 8.90
 
 Notes:
 

--- a/symbols/okta/okta_A1g_summary.md
+++ b/symbols/okta/okta_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -76.61%
 - **Rebalances executed**: 39
 - **P/E ratio (as of 2025-09-21)**: 111.15
+- **PEG ratio (as of 2025-09-21)**: 8.90
 
 Notes:
 

--- a/symbols/orcl/fundamentals.json
+++ b/symbols/orcl/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 71.44907,
+  "peg_ratio": 3.11,
   "source": "yfinance",
   "symbol": "ORCL"
 }

--- a/symbols/orcl/orcl_A1_summary.md
+++ b/symbols/orcl/orcl_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -99.83%
 - **Rebalances executed**: 107
 - **P/E ratio (as of 2025-09-21)**: 71.45
+- **PEG ratio (as of 2025-09-21)**: 3.11
 
 Notes:
 

--- a/symbols/orcl/orcl_A1g_summary.md
+++ b/symbols/orcl/orcl_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -99.38%
 - **Rebalances executed**: 188
 - **P/E ratio (as of 2025-09-21)**: 71.45
+- **PEG ratio (as of 2025-09-21)**: 3.11
 
 Notes:
 

--- a/symbols/panw/fundamentals.json
+++ b/symbols/panw/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 130.11874,
+  "peg_ratio": 9.69,
   "source": "yfinance",
   "symbol": "PANW"
 }

--- a/symbols/panw/panw_A1_summary.md
+++ b/symbols/panw/panw_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -89.52%
 - **Rebalances executed**: 70
 - **P/E ratio (as of 2025-09-21)**: 130.12
+- **PEG ratio (as of 2025-09-21)**: 9.69
 
 Notes:
 

--- a/symbols/panw/panw_A1g_summary.md
+++ b/symbols/panw/panw_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -84.65%
 - **Rebalances executed**: 69
 - **P/E ratio (as of 2025-09-21)**: 130.12
+- **PEG ratio (as of 2025-09-21)**: 9.69
 
 Notes:
 

--- a/symbols/pep/fundamentals.json
+++ b/symbols/pep/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 25.821493,
+  "peg_ratio": 7.74,
   "source": "yfinance",
   "symbol": "PEP"
 }

--- a/symbols/pep/pep_A1_summary.md
+++ b/symbols/pep/pep_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -92.97%
 - **Rebalances executed**: 173
 - **P/E ratio (as of 2025-09-21)**: 25.82
+- **PEG ratio (as of 2025-09-21)**: 7.74
 
 Notes:
 

--- a/symbols/pep/pep_A1g_summary.md
+++ b/symbols/pep/pep_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -79.76%
 - **Rebalances executed**: 225
 - **P/E ratio (as of 2025-09-21)**: 25.82
+- **PEG ratio (as of 2025-09-21)**: 7.74
 
 Notes:
 

--- a/symbols/pfe/fundamentals.json
+++ b/symbols/pfe/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 12.714286,
+  "peg_ratio": 106.52,
   "source": "yfinance",
   "symbol": "PFE"
 }

--- a/symbols/pfe/pfe_A1_summary.md
+++ b/symbols/pfe/pfe_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -97.21%
 - **Rebalances executed**: 196
 - **P/E ratio (as of 2025-09-21)**: 12.71
+- **PEG ratio (as of 2025-09-21)**: 106.52
 
 Notes:
 

--- a/symbols/pfe/pfe_A1g_summary.md
+++ b/symbols/pfe/pfe_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -95.01%
 - **Rebalances executed**: 255
 - **P/E ratio (as of 2025-09-21)**: 12.71
+- **PEG ratio (as of 2025-09-21)**: 106.52
 
 Notes:
 

--- a/symbols/pg/fundamentals.json
+++ b/symbols/pg/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 23.969276,
+  "peg_ratio": 4.78,
   "source": "yfinance",
   "symbol": "PG"
 }

--- a/symbols/pg/pg_A1_summary.md
+++ b/symbols/pg/pg_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -93.79%
 - **Rebalances executed**: 263
 - **P/E ratio (as of 2025-09-21)**: 23.97
+- **PEG ratio (as of 2025-09-21)**: 4.78
 
 Notes:
 

--- a/symbols/pg/pg_A1g_summary.md
+++ b/symbols/pg/pg_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -84.94%
 - **Rebalances executed**: 337
 - **P/E ratio (as of 2025-09-21)**: 23.97
+- **PEG ratio (as of 2025-09-21)**: 4.78
 
 Notes:
 

--- a/symbols/pltr/fundamentals.json
+++ b/symbols/pltr/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 628.931,
+  "peg_ratio": 15.05,
   "source": "yfinance",
   "symbol": "PLTR"
 }

--- a/symbols/pltr/pltr_A1_summary.md
+++ b/symbols/pltr/pltr_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -97.15%
 - **Rebalances executed**: 13
 - **P/E ratio (as of 2025-09-21)**: 628.93
+- **PEG ratio (as of 2025-09-21)**: 15.05
 
 Notes:
 

--- a/symbols/pltr/pltr_A1g_summary.md
+++ b/symbols/pltr/pltr_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -97.61%
 - **Rebalances executed**: 19
 - **P/E ratio (as of 2025-09-21)**: 628.93
+- **PEG ratio (as of 2025-09-21)**: 15.05
 
 Notes:
 

--- a/symbols/pm/fundamentals.json
+++ b/symbols/pm/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 24.105028,
+  "peg_ratio": 2.62,
   "source": "yfinance",
   "symbol": "PM"
 }

--- a/symbols/pm/pm_A1_summary.md
+++ b/symbols/pm/pm_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -79.53%
 - **Rebalances executed**: 98
 - **P/E ratio (as of 2025-09-21)**: 24.11
+- **PEG ratio (as of 2025-09-21)**: 2.62
 
 Notes:
 

--- a/symbols/pm/pm_A1g_summary.md
+++ b/symbols/pm/pm_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -82.05%
 - **Rebalances executed**: 100
 - **P/E ratio (as of 2025-09-21)**: 24.11
+- **PEG ratio (as of 2025-09-21)**: 2.62
 
 Notes:
 

--- a/symbols/pypl/fundamentals.json
+++ b/symbols/pypl/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 14.608137,
+  "peg_ratio": 1.17,
   "source": "yfinance",
   "symbol": "PYPL"
 }

--- a/symbols/pypl/pypl_A1_summary.md
+++ b/symbols/pypl/pypl_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -94.90%
 - **Rebalances executed**: 31
 - **P/E ratio (as of 2025-09-21)**: 14.61
+- **PEG ratio (as of 2025-09-21)**: 1.17
 
 Notes:
 

--- a/symbols/pypl/pypl_A1g_summary.md
+++ b/symbols/pypl/pypl_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -88.80%
 - **Rebalances executed**: 56
 - **P/E ratio (as of 2025-09-21)**: 14.61
+- **PEG ratio (as of 2025-09-21)**: 1.17
 
 Notes:
 

--- a/symbols/qcom/fundamentals.json
+++ b/symbols/qcom/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 16.105213,
+  "peg_ratio": 1.9,
   "source": "yfinance",
   "symbol": "QCOM"
 }

--- a/symbols/qcom/qcom_A1_summary.md
+++ b/symbols/qcom/qcom_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -99.95%
 - **Rebalances executed**: 118
 - **P/E ratio (as of 2025-09-21)**: 16.11
+- **PEG ratio (as of 2025-09-21)**: 1.90
 
 Notes:
 

--- a/symbols/qcom/qcom_A1g_summary.md
+++ b/symbols/qcom/qcom_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -99.26%
 - **Rebalances executed**: 153
 - **P/E ratio (as of 2025-09-21)**: 16.11
+- **PEG ratio (as of 2025-09-21)**: 1.90
 
 Notes:
 

--- a/symbols/qqq/fundamentals.json
+++ b/symbols/qqq/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 34.423325,
+  "peg_ratio": null,
   "source": "yfinance",
   "symbol": "QQQ"
 }

--- a/symbols/qqq/qqq_A11_summary.md
+++ b/symbols/qqq/qqq_A11_summary.md
@@ -1,0 +1,15 @@
+# QQQ – Strategy A11 Summary
+
+- **Span**: 1971-02-05 → 2025-09-19 (54.62 years)
+- **Underlying (Unified Nasdaq) CAGR**: 12.77%
+- **Fitted curve CAGR**: 13.37%
+- **Strategy CAGR**: 33.10%
+- **Max drawdown**: -93.09%
+- **Rebalances executed**: 354
+- **P/E ratio (as of 2025-09-21)**: 34.42
+- **PEG ratio (as of 2025-09-21)**: N/A
+
+Notes:
+
+- Temperatures and anchors per experiment govern deployment; see EXPERIMENTS.md for details.
+- Figures use simulated leveraged sleeve with fees and borrow costs.

--- a/symbols/qqq/qqq_A1_summary.md
+++ b/symbols/qqq/qqq_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -79.73%
 - **Rebalances executed**: 240
 - **P/E ratio (as of 2025-09-21)**: 34.42
+- **PEG ratio (as of 2025-09-21)**: N/A
 
 Notes:
 

--- a/symbols/qqq/qqq_A2_summary.md
+++ b/symbols/qqq/qqq_A2_summary.md
@@ -1,0 +1,15 @@
+# QQQ – Strategy A2 Summary
+
+- **Span**: 1971-02-05 → 2025-09-19 (54.62 years)
+- **Underlying (Unified Nasdaq) CAGR**: 12.77%
+- **Fitted curve CAGR**: 13.37%
+- **Strategy CAGR**: 30.06%
+- **Max drawdown**: -80.08%
+- **Rebalances executed**: 288
+- **P/E ratio (as of 2025-09-21)**: 34.42
+- **PEG ratio (as of 2025-09-21)**: N/A
+
+Notes:
+
+- Temperatures and anchors per experiment govern deployment; see EXPERIMENTS.md for details.
+- Figures use simulated leveraged sleeve with fees and borrow costs.

--- a/symbols/qqq/qqq_A3_summary.md
+++ b/symbols/qqq/qqq_A3_summary.md
@@ -1,0 +1,15 @@
+# QQQ – Strategy A3 Summary
+
+- **Span**: 1971-02-05 → 2025-09-19 (54.62 years)
+- **Underlying (Unified Nasdaq) CAGR**: 12.77%
+- **Fitted curve CAGR**: 13.37%
+- **Strategy CAGR**: 30.10%
+- **Max drawdown**: -80.44%
+- **Rebalances executed**: 286
+- **P/E ratio (as of 2025-09-21)**: 34.42
+- **PEG ratio (as of 2025-09-21)**: N/A
+
+Notes:
+
+- Temperatures and anchors per experiment govern deployment; see EXPERIMENTS.md for details.
+- Figures use simulated leveraged sleeve with fees and borrow costs.

--- a/symbols/qqq/qqq_A4_summary.md
+++ b/symbols/qqq/qqq_A4_summary.md
@@ -1,0 +1,15 @@
+# QQQ – Strategy A4 Summary
+
+- **Span**: 1971-02-05 → 2025-09-19 (54.62 years)
+- **Underlying (Unified Nasdaq) CAGR**: 12.77%
+- **Fitted curve CAGR**: 13.37%
+- **Strategy CAGR**: 30.65%
+- **Max drawdown**: -83.44%
+- **Rebalances executed**: 305
+- **P/E ratio (as of 2025-09-21)**: 34.42
+- **PEG ratio (as of 2025-09-21)**: N/A
+
+Notes:
+
+- Temperatures and anchors per experiment govern deployment; see EXPERIMENTS.md for details.
+- Figures use simulated leveraged sleeve with fees and borrow costs.

--- a/symbols/qqq/qqq_A5_summary.md
+++ b/symbols/qqq/qqq_A5_summary.md
@@ -1,0 +1,15 @@
+# QQQ – Strategy A5 Summary
+
+- **Span**: 1971-02-05 → 2025-09-19 (54.62 years)
+- **Underlying (Unified Nasdaq) CAGR**: 12.77%
+- **Fitted curve CAGR**: 13.37%
+- **Strategy CAGR**: 31.25%
+- **Max drawdown**: -83.44%
+- **Rebalances executed**: 295
+- **P/E ratio (as of 2025-09-21)**: 34.42
+- **PEG ratio (as of 2025-09-21)**: N/A
+
+Notes:
+
+- Temperatures and anchors per experiment govern deployment; see EXPERIMENTS.md for details.
+- Figures use simulated leveraged sleeve with fees and borrow costs.

--- a/symbols/qqq/qqq_A7_summary.md
+++ b/symbols/qqq/qqq_A7_summary.md
@@ -1,0 +1,15 @@
+# QQQ – Strategy A7 Summary
+
+- **Span**: 1971-02-05 → 2025-09-19 (54.62 years)
+- **Underlying (Unified Nasdaq) CAGR**: 12.77%
+- **Fitted curve CAGR**: 13.37%
+- **Strategy CAGR**: 32.76%
+- **Max drawdown**: -91.39%
+- **Rebalances executed**: 340
+- **P/E ratio (as of 2025-09-21)**: 34.42
+- **PEG ratio (as of 2025-09-21)**: N/A
+
+Notes:
+
+- Temperatures and anchors per experiment govern deployment; see EXPERIMENTS.md for details.
+- Figures use simulated leveraged sleeve with fees and borrow costs.

--- a/symbols/rtx/fundamentals.json
+++ b/symbols/rtx/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 34.701756,
+  "peg_ratio": 3.77,
   "source": "yfinance",
   "symbol": "RTX"
 }

--- a/symbols/rtx/rtx_A1_summary.md
+++ b/symbols/rtx/rtx_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -97.45%
 - **Rebalances executed**: 236
 - **P/E ratio (as of 2025-09-21)**: 34.70
+- **PEG ratio (as of 2025-09-21)**: 3.77
 
 Notes:
 

--- a/symbols/rtx/rtx_A1g_summary.md
+++ b/symbols/rtx/rtx_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -95.50%
 - **Rebalances executed**: 312
 - **P/E ratio (as of 2025-09-21)**: 34.70
+- **PEG ratio (as of 2025-09-21)**: 3.77
 
 Notes:
 

--- a/symbols/sbux/fundamentals.json
+++ b/symbols/sbux/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 36.60606,
+  "peg_ratio": 110.82,
   "source": "yfinance",
   "symbol": "SBUX"
 }

--- a/symbols/sbux/sbux_A1_summary.md
+++ b/symbols/sbux/sbux_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -97.40%
 - **Rebalances executed**: 138
 - **P/E ratio (as of 2025-09-21)**: 36.61
+- **PEG ratio (as of 2025-09-21)**: 110.82
 
 Notes:
 

--- a/symbols/sbux/sbux_A1g_summary.md
+++ b/symbols/sbux/sbux_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -96.20%
 - **Rebalances executed**: 175
 - **P/E ratio (as of 2025-09-21)**: 36.61
+- **PEG ratio (as of 2025-09-21)**: 110.82
 
 Notes:
 

--- a/symbols/schw/fundamentals.json
+++ b/symbols/schw/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 25.357527,
+  "peg_ratio": 1.04,
   "source": "yfinance",
   "symbol": "SCHW"
 }

--- a/symbols/schw/schw_A1_summary.md
+++ b/symbols/schw/schw_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -93.80%
 - **Rebalances executed**: 110
 - **P/E ratio (as of 2025-09-21)**: 25.36
+- **PEG ratio (as of 2025-09-21)**: 1.04
 
 Notes:
 

--- a/symbols/schw/schw_A1g_summary.md
+++ b/symbols/schw/schw_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -92.83%
 - **Rebalances executed**: 167
 - **P/E ratio (as of 2025-09-21)**: 25.36
+- **PEG ratio (as of 2025-09-21)**: 1.04
 
 Notes:
 

--- a/symbols/shop/fundamentals.json
+++ b/symbols/shop/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 85.64246,
+  "peg_ratio": 3.67,
   "source": "yfinance",
   "symbol": "SHOP"
 }

--- a/symbols/shop/shop_A1_summary.md
+++ b/symbols/shop/shop_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -92.57%
 - **Rebalances executed**: 43
 - **P/E ratio (as of 2025-09-21)**: 85.64
+- **PEG ratio (as of 2025-09-21)**: 3.67
 
 Notes:
 

--- a/symbols/shop/shop_A1g_summary.md
+++ b/symbols/shop/shop_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -91.86%
 - **Rebalances executed**: 46
 - **P/E ratio (as of 2025-09-21)**: 85.64
+- **PEG ratio (as of 2025-09-21)**: 3.67
 
 Notes:
 

--- a/symbols/smci/fundamentals.json
+++ b/symbols/smci/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 27.267859,
+  "peg_ratio": 1.51,
   "source": "yfinance",
   "symbol": "SMCI"
 }

--- a/symbols/smci/smci_A1_summary.md
+++ b/symbols/smci/smci_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -405.75%
 - **Rebalances executed**: 61
 - **P/E ratio (as of 2025-09-21)**: 27.27
+- **PEG ratio (as of 2025-09-21)**: 1.51
 
 Notes:
 

--- a/symbols/smci/smci_A1g_summary.md
+++ b/symbols/smci/smci_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -890.53%
 - **Rebalances executed**: 94
 - **P/E ratio (as of 2025-09-21)**: 27.27
+- **PEG ratio (as of 2025-09-21)**: 1.51
 
 Notes:
 

--- a/symbols/smh/fundamentals.json
+++ b/symbols/smh/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 37.996155,
+  "peg_ratio": null,
   "source": "yfinance",
   "symbol": "SMH"
 }

--- a/symbols/snow/fundamentals.json
+++ b/symbols/snow/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 247.82796,
+  "peg_ratio": 5.897857210851974,
   "source": "yfinance",
   "symbol": "SNOW"
 }

--- a/symbols/snow/snow_A1_summary.md
+++ b/symbols/snow/snow_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -98.21%
 - **Rebalances executed**: 33
 - **P/E ratio (as of 2025-09-21)**: 247.83
+- **PEG ratio (as of 2025-09-21)**: 5.90
 
 Notes:
 

--- a/symbols/snow/snow_A1g_summary.md
+++ b/symbols/snow/snow_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -97.00%
 - **Rebalances executed**: 31
 - **P/E ratio (as of 2025-09-21)**: 247.83
+- **PEG ratio (as of 2025-09-21)**: 5.90
 
 Notes:
 

--- a/symbols/so/fundamentals.json
+++ b/symbols/so/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 23.720932,
+  "peg_ratio": 3.51,
   "source": "yfinance",
   "symbol": "SO"
 }

--- a/symbols/so/so_A1_summary.md
+++ b/symbols/so/so_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -78.07%
 - **Rebalances executed**: 219
 - **P/E ratio (as of 2025-09-21)**: 23.72
+- **PEG ratio (as of 2025-09-21)**: 3.51
 
 Notes:
 

--- a/symbols/so/so_A1g_summary.md
+++ b/symbols/so/so_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -72.31%
 - **Rebalances executed**: 254
 - **P/E ratio (as of 2025-09-21)**: 23.72
+- **PEG ratio (as of 2025-09-21)**: 3.51
 
 Notes:
 

--- a/symbols/sol-usd/fundamentals.json
+++ b/symbols/sol-usd/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": null,
+  "peg_ratio": null,
   "source": "yfinance",
   "symbol": "SOL-USD"
 }

--- a/symbols/spgi/fundamentals.json
+++ b/symbols/spgi/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 38.92249,
+  "peg_ratio": 3.51,
   "source": "yfinance",
   "symbol": "SPGI"
 }

--- a/symbols/spgi/spgi_A1_summary.md
+++ b/symbols/spgi/spgi_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -99.56%
 - **Rebalances executed**: 213
 - **P/E ratio (as of 2025-09-21)**: 38.92
+- **PEG ratio (as of 2025-09-21)**: 3.51
 
 Notes:
 

--- a/symbols/spgi/spgi_A1g_summary.md
+++ b/symbols/spgi/spgi_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -98.23%
 - **Rebalances executed**: 260
 - **P/E ratio (as of 2025-09-21)**: 38.92
+- **PEG ratio (as of 2025-09-21)**: 3.51
 
 Notes:
 

--- a/symbols/spy/fundamentals.json
+++ b/symbols/spy/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 28.034864,
+  "peg_ratio": null,
   "source": "yfinance",
   "symbol": "SPY"
 }

--- a/symbols/syk/fundamentals.json
+++ b/symbols/syk/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 49.97745,
+  "peg_ratio": 4.48,
   "source": "yfinance",
   "symbol": "SYK"
 }

--- a/symbols/syk/syk_A1_summary.md
+++ b/symbols/syk/syk_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -93.66%
 - **Rebalances executed**: 147
 - **P/E ratio (as of 2025-09-21)**: 49.98
+- **PEG ratio (as of 2025-09-21)**: 4.48
 
 Notes:
 

--- a/symbols/syk/syk_A1g_summary.md
+++ b/symbols/syk/syk_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -87.94%
 - **Rebalances executed**: 200
 - **P/E ratio (as of 2025-09-21)**: 49.98
+- **PEG ratio (as of 2025-09-21)**: 4.48
 
 Notes:
 

--- a/symbols/t/fundamentals.json
+++ b/symbols/t/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 16.577143,
+  "peg_ratio": 4.71,
   "source": "yfinance",
   "symbol": "T"
 }

--- a/symbols/t/t_A1_summary.md
+++ b/symbols/t/t_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -86.25%
 - **Rebalances executed**: 178
 - **P/E ratio (as of 2025-09-21)**: 16.58
+- **PEG ratio (as of 2025-09-21)**: 4.71
 
 Notes:
 

--- a/symbols/t/t_A1g_summary.md
+++ b/symbols/t/t_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -83.87%
 - **Rebalances executed**: 226
 - **P/E ratio (as of 2025-09-21)**: 16.58
+- **PEG ratio (as of 2025-09-21)**: 4.71
 
 Notes:
 

--- a/symbols/team/fundamentals.json
+++ b/symbols/team/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 41.131386,
+  "peg_ratio": 1.8989559556786704,
   "source": "yfinance",
   "symbol": "TEAM"
 }

--- a/symbols/team/team_A1_summary.md
+++ b/symbols/team/team_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -97.54%
 - **Rebalances executed**: 30
 - **P/E ratio (as of 2025-09-21)**: 41.13
+- **PEG ratio (as of 2025-09-21)**: 1.90
 
 Notes:
 

--- a/symbols/team/team_A1g_summary.md
+++ b/symbols/team/team_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -89.29%
 - **Rebalances executed**: 47
 - **P/E ratio (as of 2025-09-21)**: 41.13
+- **PEG ratio (as of 2025-09-21)**: 1.90
 
 Notes:
 

--- a/symbols/tmo/fundamentals.json
+++ b/symbols/tmo/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 27.705372,
+  "peg_ratio": 3.88,
   "source": "yfinance",
   "symbol": "TMO"
 }

--- a/symbols/tmo/tmo_A1_summary.md
+++ b/symbols/tmo/tmo_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -92.38%
 - **Rebalances executed**: 161
 - **P/E ratio (as of 2025-09-21)**: 27.71
+- **PEG ratio (as of 2025-09-21)**: 3.88
 
 Notes:
 

--- a/symbols/tmo/tmo_A1g_summary.md
+++ b/symbols/tmo/tmo_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -83.49%
 - **Rebalances executed**: 216
 - **P/E ratio (as of 2025-09-21)**: 27.71
+- **PEG ratio (as of 2025-09-21)**: 3.88
 
 Notes:
 

--- a/symbols/tsla/fundamentals.json
+++ b/symbols/tsla/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 256.66867,
+  "peg_ratio": 17.65,
   "source": "yfinance",
   "symbol": "TSLA"
 }

--- a/symbols/tsla/tsla_A1_summary.md
+++ b/symbols/tsla/tsla_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -97.06%
 - **Rebalances executed**: 59
 - **P/E ratio (as of 2025-09-21)**: 256.67
+- **PEG ratio (as of 2025-09-21)**: 17.65
 
 Notes:
 

--- a/symbols/tsla/tsla_A1g_summary.md
+++ b/symbols/tsla/tsla_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -95.41%
 - **Rebalances executed**: 64
 - **P/E ratio (as of 2025-09-21)**: 256.67
+- **PEG ratio (as of 2025-09-21)**: 17.65
 
 Notes:
 

--- a/symbols/tsm/fundamentals.json
+++ b/symbols/tsm/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 28.665585,
+  "peg_ratio": 1.21,
   "source": "yfinance",
   "symbol": "TSM"
 }

--- a/symbols/tsm/tsm_A1_summary.md
+++ b/symbols/tsm/tsm_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -96.51%
 - **Rebalances executed**: 107
 - **P/E ratio (as of 2025-09-21)**: 28.67
+- **PEG ratio (as of 2025-09-21)**: 1.21
 
 Notes:
 

--- a/symbols/tsm/tsm_A1g_summary.md
+++ b/symbols/tsm/tsm_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -89.16%
 - **Rebalances executed**: 139
 - **P/E ratio (as of 2025-09-21)**: 28.67
+- **PEG ratio (as of 2025-09-21)**: 1.21
 
 Notes:
 

--- a/symbols/ttd/fundamentals.json
+++ b/symbols/ttd/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 53.578316,
+  "peg_ratio": 2.8423509814323604,
   "source": "yfinance",
   "symbol": "TTD"
 }

--- a/symbols/ttd/ttd_A1_summary.md
+++ b/symbols/ttd/ttd_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -103.70%
 - **Rebalances executed**: 35
 - **P/E ratio (as of 2025-09-21)**: 53.58
+- **PEG ratio (as of 2025-09-21)**: 2.84
 
 Notes:
 

--- a/symbols/ttd/ttd_A1g_summary.md
+++ b/symbols/ttd/ttd_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -104.03%
 - **Rebalances executed**: 40
 - **P/E ratio (as of 2025-09-21)**: 53.58
+- **PEG ratio (as of 2025-09-21)**: 2.84
 
 Notes:
 

--- a/symbols/txn/fundamentals.json
+++ b/symbols/txn/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 32.79159,
+  "peg_ratio": 2.27,
   "source": "yfinance",
   "symbol": "TXN"
 }

--- a/symbols/txn/txn_A1_summary.md
+++ b/symbols/txn/txn_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -99.71%
 - **Rebalances executed**: 184
 - **P/E ratio (as of 2025-09-21)**: 32.79
+- **PEG ratio (as of 2025-09-21)**: 2.27
 
 Notes:
 

--- a/symbols/txn/txn_A1g_summary.md
+++ b/symbols/txn/txn_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -98.53%
 - **Rebalances executed**: 280
 - **P/E ratio (as of 2025-09-21)**: 32.79
+- **PEG ratio (as of 2025-09-21)**: 2.27
 
 Notes:
 

--- a/symbols/unh/fundamentals.json
+++ b/symbols/unh/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 14.575325,
+  "peg_ratio": 1.285301971547532,
   "source": "yfinance",
   "symbol": "UNH"
 }

--- a/symbols/unh/unh_A1_summary.md
+++ b/symbols/unh/unh_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -601.10%
 - **Rebalances executed**: 133
 - **P/E ratio (as of 2025-09-21)**: 14.58
+- **PEG ratio (as of 2025-09-21)**: 1.29
 
 Notes:
 

--- a/symbols/unh/unh_A1g_summary.md
+++ b/symbols/unh/unh_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -99.83%
 - **Rebalances executed**: 175
 - **P/E ratio (as of 2025-09-21)**: 14.58
+- **PEG ratio (as of 2025-09-21)**: 1.29
 
 Notes:
 

--- a/symbols/ups/fundamentals.json
+++ b/symbols/ups/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 12.508928,
+  "peg_ratio": 10.16,
   "source": "yfinance",
   "symbol": "UPS"
 }

--- a/symbols/ups/ups_A1_summary.md
+++ b/symbols/ups/ups_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -94.52%
 - **Rebalances executed**: 131
 - **P/E ratio (as of 2025-09-21)**: 12.51
+- **PEG ratio (as of 2025-09-21)**: 10.16
 
 Notes:
 

--- a/symbols/ups/ups_A1g_summary.md
+++ b/symbols/ups/ups_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -90.96%
 - **Rebalances executed**: 148
 - **P/E ratio (as of 2025-09-21)**: 12.51
+- **PEG ratio (as of 2025-09-21)**: 10.16
 
 Notes:
 

--- a/symbols/usb/fundamentals.json
+++ b/symbols/usb/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 12.059809,
+  "peg_ratio": 1.0,
   "source": "yfinance",
   "symbol": "USB"
 }

--- a/symbols/usb/usb_A1_summary.md
+++ b/symbols/usb/usb_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -97.96%
 - **Rebalances executed**: 200
 - **P/E ratio (as of 2025-09-21)**: 12.06
+- **PEG ratio (as of 2025-09-21)**: 1.00
 
 Notes:
 

--- a/symbols/usb/usb_A1g_summary.md
+++ b/symbols/usb/usb_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -95.31%
 - **Rebalances executed**: 253
 - **P/E ratio (as of 2025-09-21)**: 12.06
+- **PEG ratio (as of 2025-09-21)**: 1.00
 
 Notes:
 

--- a/symbols/v/fundamentals.json
+++ b/symbols/v/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 33.327805,
+  "peg_ratio": 2.59,
   "source": "yfinance",
   "symbol": "V"
 }

--- a/symbols/v/v_A1_summary.md
+++ b/symbols/v/v_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -89.85%
 - **Rebalances executed**: 73
 - **P/E ratio (as of 2025-09-21)**: 33.33
+- **PEG ratio (as of 2025-09-21)**: 2.59
 
 Notes:
 

--- a/symbols/v/v_A1g_summary.md
+++ b/symbols/v/v_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -86.23%
 - **Rebalances executed**: 99
 - **P/E ratio (as of 2025-09-21)**: 33.33
+- **PEG ratio (as of 2025-09-21)**: 2.59
 
 Notes:
 

--- a/symbols/vz/fundamentals.json
+++ b/symbols/vz/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 10.111628,
+  "peg_ratio": 2.9,
   "source": "yfinance",
   "symbol": "VZ"
 }

--- a/symbols/vz/vz_A1_summary.md
+++ b/symbols/vz/vz_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -89.40%
 - **Rebalances executed**: 190
 - **P/E ratio (as of 2025-09-21)**: 10.11
+- **PEG ratio (as of 2025-09-21)**: 2.90
 
 Notes:
 

--- a/symbols/vz/vz_A1g_summary.md
+++ b/symbols/vz/vz_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -81.16%
 - **Rebalances executed**: 233
 - **P/E ratio (as of 2025-09-21)**: 10.11
+- **PEG ratio (as of 2025-09-21)**: 2.90
 
 Notes:
 

--- a/symbols/wmt/fundamentals.json
+++ b/symbols/wmt/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 38.615093,
+  "peg_ratio": 4.12,
   "source": "yfinance",
   "symbol": "WMT"
 }

--- a/symbols/wmt/wmt_A1_summary.md
+++ b/symbols/wmt/wmt_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -99.50%
 - **Rebalances executed**: 97
 - **P/E ratio (as of 2025-09-21)**: 38.62
+- **PEG ratio (as of 2025-09-21)**: 4.12
 
 Notes:
 

--- a/symbols/wmt/wmt_A1g_summary.md
+++ b/symbols/wmt/wmt_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -96.55%
 - **Rebalances executed**: 190
 - **P/E ratio (as of 2025-09-21)**: 38.62
+- **PEG ratio (as of 2025-09-21)**: 4.12
 
 Notes:
 

--- a/symbols/xlk/fundamentals.json
+++ b/symbols/xlk/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 39.67864,
+  "peg_ratio": null,
   "source": "yfinance",
   "symbol": "XLK"
 }

--- a/symbols/xom/fundamentals.json
+++ b/symbols/xom/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 16.025568,
+  "peg_ratio": 2.81,
   "source": "yfinance",
   "symbol": "XOM"
 }

--- a/symbols/xom/xom_A1_summary.md
+++ b/symbols/xom/xom_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -98.91%
 - **Rebalances executed**: 190
 - **P/E ratio (as of 2025-09-21)**: 16.03
+- **PEG ratio (as of 2025-09-21)**: 2.81
 
 Notes:
 

--- a/symbols/xom/xom_A1g_summary.md
+++ b/symbols/xom/xom_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -96.79%
 - **Rebalances executed**: 313
 - **P/E ratio (as of 2025-09-21)**: 16.03
+- **PEG ratio (as of 2025-09-21)**: 2.81
 
 Notes:
 

--- a/symbols/zm/fundamentals.json
+++ b/symbols/zm/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 22.14737,
+  "peg_ratio": 5.28,
   "source": "yfinance",
   "symbol": "ZM"
 }

--- a/symbols/zm/zm_A1_summary.md
+++ b/symbols/zm/zm_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -94.38%
 - **Rebalances executed**: 22
 - **P/E ratio (as of 2025-09-21)**: 22.15
+- **PEG ratio (as of 2025-09-21)**: 5.28
 
 Notes:
 

--- a/symbols/zm/zm_A1g_summary.md
+++ b/symbols/zm/zm_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -93.26%
 - **Rebalances executed**: 27
 - **P/E ratio (as of 2025-09-21)**: 22.15
+- **PEG ratio (as of 2025-09-21)**: 5.28
 
 Notes:
 

--- a/symbols/zts/fundamentals.json
+++ b/symbols/zts/fundamentals.json
@@ -1,6 +1,7 @@
 {
   "as_of": "2025-09-21",
   "pe_ratio": 25.108435,
+  "peg_ratio": 2.97,
   "source": "yfinance",
   "symbol": "ZTS"
 }

--- a/symbols/zts/zts_A1_summary.md
+++ b/symbols/zts/zts_A1_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -75.43%
 - **Rebalances executed**: 71
 - **P/E ratio (as of 2025-09-21)**: 25.11
+- **PEG ratio (as of 2025-09-21)**: 2.97
 
 Notes:
 

--- a/symbols/zts/zts_A1g_summary.md
+++ b/symbols/zts/zts_A1g_summary.md
@@ -7,6 +7,7 @@
 - **Max drawdown**: -68.67%
 - **Rebalances executed**: 73
 - **P/E ratio (as of 2025-09-21)**: 25.11
+- **PEG ratio (as of 2025-09-21)**: 2.97
 
 Notes:
 

--- a/test_fundamentals.py
+++ b/test_fundamentals.py
@@ -1,0 +1,85 @@
+import datetime as dt
+import importlib.util
+import json
+from pathlib import Path
+
+import sys
+import types
+
+import pytest
+
+
+_FUNDAMENTALS_SPEC = importlib.util.spec_from_file_location(
+    "fundamentals_test_module",
+    Path(__file__).with_name("tqqq") / "fundamentals.py",
+)
+assert _FUNDAMENTALS_SPEC and _FUNDAMENTALS_SPEC.loader
+fundamentals = importlib.util.module_from_spec(_FUNDAMENTALS_SPEC)
+sys.modules[_FUNDAMENTALS_SPEC.name] = fundamentals
+_FUNDAMENTALS_SPEC.loader.exec_module(fundamentals)
+
+
+def test_missing_cached_peg_triggers_refresh(tmp_path, monkeypatch):
+    """PEG-less caches should be refreshed even when otherwise fresh."""
+
+    symbol = "ABC"
+    symbol_dir = tmp_path / symbol.lower()
+    symbol_dir.mkdir()
+
+    today_iso = dt.date.today().isoformat()
+    cache_path = symbol_dir / fundamentals.FUNDAMENTALS_FILENAME
+    cache_payload = {
+        "symbol": symbol,
+        "pe_ratio": 17.5,
+        "as_of": today_iso,
+        "source": "yfinance",
+    }
+    cache_path.write_text(json.dumps(cache_payload, indent=2, sort_keys=True) + "\n")
+
+    calls = []
+
+    def fake_fetch(requested_symbol: str):
+        calls.append(requested_symbol)
+        return 21.0, 1.4
+
+    monkeypatch.setattr(fundamentals, "fetch_fundamental_ratios", fake_fetch)
+
+    ratios = fundamentals.ensure_fundamental_ratios(symbol, str(symbol_dir))
+
+    assert calls == [symbol]
+    assert ratios.pe_ratio.value == pytest.approx(21.0)
+    assert ratios.peg_ratio.value == pytest.approx(1.4)
+
+    updated_payload = json.loads(cache_path.read_text())
+    assert updated_payload["peg_ratio"] == pytest.approx(1.4)
+    assert updated_payload["as_of"] == today_iso
+
+
+def test_fetch_ratios_falls_back_to_finviz(monkeypatch):
+    """Finviz data should be used when yfinance lacks PEG figures."""
+
+    calls = []
+
+    class DummyTicker:
+        def __init__(self, symbol: str):
+            calls.append(symbol)
+            self.fast_info = {}
+            self.info = {}
+
+    dummy_module = types.SimpleNamespace(Ticker=lambda symbol: DummyTicker(symbol))
+    monkeypatch.setitem(sys.modules, "yfinance", dummy_module)
+
+    finviz_calls = []
+
+    def fake_finviz(symbol: str):
+        finviz_calls.append(symbol)
+        return 17.2, 1.5, None
+
+    monkeypatch.setattr(fundamentals, "_fetch_finviz_ratios", fake_finviz)
+
+    pe, peg = fundamentals.fetch_fundamental_ratios("XYZ")
+
+    assert pe == pytest.approx(17.2)
+    assert peg == pytest.approx(1.5)
+    assert calls == ["XYZ"]
+    assert finviz_calls == ["XYZ"]

--- a/tqqq/__init__.py
+++ b/tqqq/__init__.py
@@ -3,7 +3,14 @@
 from .dataset import PriceDataError, load_price_csv
 from .fitting import FitResult, FitStep, fit_constant_growth, iterative_constant_growth
 from .fred import fetch_fred_series
-from .fundamentals import PERatio, ensure_pe_ratio
+from .fundamentals import (
+    FundamentalRatios,
+    PEGRatio,
+    PERatio,
+    ensure_fundamental_ratios,
+    ensure_pe_ratio,
+    ensure_peg_ratio,
+)
 from .simulation import simulate_leveraged_path
 
 __all__ = [
@@ -14,7 +21,11 @@ __all__ = [
     "fit_constant_growth",
     "iterative_constant_growth",
     "fetch_fred_series",
+    "FundamentalRatios",
     "PERatio",
+    "PEGRatio",
+    "ensure_fundamental_ratios",
     "ensure_pe_ratio",
+    "ensure_peg_ratio",
     "simulate_leveraged_path",
 ]

--- a/tqqq/fundamentals.py
+++ b/tqqq/fundamentals.py
@@ -4,14 +4,44 @@ from __future__ import annotations
 
 import datetime as _dt
 import json
+import math
 import os
 from dataclasses import dataclass
-from typing import Optional, Tuple
+from typing import Any, Optional, Tuple
 
 FUNDAMENTALS_FILENAME = "fundamentals.json"
 
 
-@dataclass
+def _format_ratio_line(label: str, value: Optional[float], as_of: Optional[str]) -> str:
+    date_display = as_of or "Unknown"
+    value_display = "N/A" if value is None else f"{value:.2f}"
+    return f"- **{label} (as of {date_display})**: {value_display}"
+
+
+def _write_cache(
+    path: str,
+    *,
+    symbol: str,
+    pe_value: Optional[float],
+    peg_value: Optional[float],
+    as_of: Optional[str],
+) -> None:
+    payload = {
+        "symbol": symbol,
+        "pe_ratio": pe_value,
+        "peg_ratio": peg_value,
+        "as_of": as_of,
+        "source": "yfinance",
+    }
+    try:
+        with open(path, "w", encoding="utf-8") as fh:
+            json.dump(payload, fh, indent=2, sort_keys=True)
+            fh.write("\n")
+    except Exception:
+        pass
+
+
+@dataclass(frozen=True)
 class PERatio:
     """Representation of a symbol's price-to-earnings ratio."""
 
@@ -20,28 +50,119 @@ class PERatio:
 
     def as_summary_line(self) -> str:
         """Format the ratio for markdown summaries."""
-        date_display = self.as_of or "Unknown"
-        value_display = "N/A" if self.value is None else f"{self.value:.2f}"
-        return f"- **P/E ratio (as of {date_display})**: {value_display}"
+        return _format_ratio_line("P/E ratio", self.value, self.as_of)
 
 
-def _load_cached(path: str) -> Tuple[Optional[float], Optional[str]]:
+@dataclass(frozen=True)
+class PEGRatio:
+    """Representation of a symbol's price/earnings-to-growth ratio."""
+
+    value: Optional[float]
+    as_of: Optional[str]
+
+    def as_summary_line(self) -> str:
+        """Format the ratio for markdown summaries."""
+        return _format_ratio_line("PEG ratio", self.value, self.as_of)
+
+
+@dataclass(frozen=True)
+class FundamentalRatios:
+    """Container for cached fundamental ratios."""
+
+    pe_ratio: PERatio
+    peg_ratio: PEGRatio
+
+
+def _coerce_number(value: Any) -> Optional[float]:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        number = float(value)
+    else:
+        try:
+            number = float(value)
+        except (TypeError, ValueError):
+            return None
+    if math.isnan(number) or math.isinf(number):
+        return None
+    return number
+
+
+def _load_cached(
+    path: str,
+) -> Tuple[Optional[float], Optional[float], Optional[str], bool]:
     if not os.path.exists(path):
-        return None, None
+        return None, None, None, False
     try:
         with open(path, "r", encoding="utf-8") as fh:
             payload = json.load(fh)
     except Exception:
-        return None, None
-    pe = payload.get("pe_ratio")
-    if isinstance(pe, (int, float)):
-        pe_value: Optional[float] = float(pe)
-    else:
-        pe_value = None
+        return None, None, None, False
+    pe_value = _coerce_number(payload.get("pe_ratio"))
+    peg_value = _coerce_number(payload.get("peg_ratio"))
     as_of = payload.get("as_of")
+    has_peg_key = "peg_ratio" in payload
     if isinstance(as_of, str):
-        return pe_value, as_of
-    return pe_value, None
+        return pe_value, peg_value, as_of, has_peg_key
+    return pe_value, peg_value, None, has_peg_key
+
+
+def _fetch_finviz_ratios(
+    symbol: str,
+) -> Tuple[Optional[float], Optional[float], Optional[float]]:
+    """Fetch P/E, PEG, and growth forecasts from Finviz as a fallback."""
+
+    try:
+        import requests
+        from bs4 import BeautifulSoup  # type: ignore
+    except ImportError:  # pragma: no cover - optional dependency
+        return None, None, None
+
+    url = f"https://finviz.com/quote.ashx?t={symbol}"
+    try:
+        response = requests.get(
+            url,
+            timeout=10,
+            headers={"User-Agent": "Mozilla/5.0"},
+        )
+        response.raise_for_status()
+    except Exception:
+        return None, None, None
+
+    soup = BeautifulSoup(response.text, "html.parser")
+    labels = soup.select("td.snapshot-td2")
+    if not labels:
+        return None, None, None
+
+    def parse_snapshot_value(raw: str) -> Optional[float]:
+        text = raw.strip()
+        if not text or text.upper() in {"-", "N/A"}:
+            return None
+        sanitized = text.replace(",", "")
+        if sanitized.endswith("%"):
+            sanitized = sanitized[:-1]
+        return _coerce_number(sanitized)
+
+    pe_value: Optional[float] = None
+    peg_value: Optional[float] = None
+    eps_next_5y: Optional[float] = None
+
+    for cell in labels:
+        label = cell.get_text(strip=True).upper()
+        value_cell = cell.find_next_sibling("td")
+        if not value_cell:
+            continue
+        raw_value = value_cell.get_text(strip=True)
+        if label == "P/E" and pe_value is None:
+            pe_value = parse_snapshot_value(raw_value)
+        elif label == "PEG" and peg_value is None:
+            peg_value = parse_snapshot_value(raw_value)
+        elif label == "EPS NEXT 5Y" and eps_next_5y is None:
+            eps_next_5y = parse_snapshot_value(raw_value)
+        if pe_value is not None and peg_value is not None:
+            break
+
+    return pe_value, peg_value, eps_next_5y
 
 
 def _days_between(date_iso: str, today_iso: str) -> Optional[int]:
@@ -53,108 +174,202 @@ def _days_between(date_iso: str, today_iso: str) -> Optional[int]:
     return (today_val - date_val).days
 
 
-def fetch_pe_ratio(symbol: str) -> Optional[float]:
-    """Fetch the trailing P/E ratio for ``symbol`` using yfinance.
-
-    Returns ``None`` when data is unavailable.
-    """
+def fetch_fundamental_ratios(symbol: str) -> Tuple[Optional[float], Optional[float]]:
+    """Fetch trailing P/E and PEG ratios for ``symbol`` using yfinance."""
 
     try:
         import yfinance as yf  # type: ignore
     except ImportError:  # pragma: no cover - runtime dependency
-        return None
+        return None, None
 
     ticker = yf.Ticker(symbol)
     pe_value: Optional[float] = None
+    peg_value: Optional[float] = None
 
-    # ``fast_info`` avoids a full fundamental download and is the quickest path.
     try:  # pragma: no branch - simple guard
         fast_info = getattr(ticker, "fast_info", None)
         if fast_info:
-            pe_value = fast_info.get("trailing_pe")
+            pe_value = _coerce_number(fast_info.get("trailing_pe"))
             if pe_value is None:
-                pe_value = fast_info.get("pe_ratio")
-            if pe_value is not None:
-                pe_value = float(pe_value)
+                pe_value = _coerce_number(fast_info.get("pe_ratio"))
+            peg_value = _coerce_number(fast_info.get("peg_ratio"))
     except Exception:
-        pe_value = None
+        pe_value = pe_value if pe_value is not None else None
+        peg_value = peg_value if peg_value is not None else None
 
-    if pe_value is None:
+    growth_percent: Optional[float] = None
+
+    if pe_value is None or peg_value is None:
         try:
             info = ticker.info  # type: ignore[attr-defined]
         except Exception:
             info = None
         if isinstance(info, dict):
-            for key in ("trailingPE", "forwardPE"):
-                raw = info.get(key)
-                if raw is not None:
-                    try:
-                        pe_value = float(raw)
+            if pe_value is None:
+                for key in ("trailingPE", "forwardPE"):
+                    pe_value = _coerce_number(info.get(key))
+                    if pe_value is not None:
                         break
-                    except (TypeError, ValueError):
-                        continue
+            if peg_value is None:
+                peg_value = _coerce_number(info.get("pegRatio"))
 
-    return pe_value
+    if peg_value is None:
+        try:
+            growth_df = ticker.get_growth_estimates()  # type: ignore[attr-defined]
+        except Exception:
+            growth_df = None
+        if growth_df is not None and hasattr(growth_df, "loc"):
+            for label in ("LTG", "+1y", "+5y", "0y"):
+                try:
+                    row = growth_df.loc[label]
+                except Exception:
+                    continue
+                candidate: Optional[float] = None
+                if hasattr(row, "__getitem__"):
+                    try:
+                        candidate = _coerce_number(row["stockTrend"])
+                    except Exception:
+                        candidate = _coerce_number(row)
+                else:
+                    candidate = _coerce_number(row)
+                if candidate is not None:
+                    growth_percent = candidate * 100.0
+                    break
+        if (
+            growth_percent is not None
+            and pe_value is not None
+            and growth_percent not in (0.0, -0.0)
+        ):
+            peg_value = pe_value / growth_percent
+
+    if pe_value is None or peg_value is None:
+        fallback_pe, fallback_peg, fallback_growth = _fetch_finviz_ratios(symbol)
+        if pe_value is None:
+            pe_value = fallback_pe
+        if peg_value is None:
+            peg_value = fallback_peg
+        if (
+            peg_value is None
+            and pe_value is not None
+            and fallback_growth is not None
+            and fallback_growth not in (0.0, -0.0)
+        ):
+            peg_value = pe_value / fallback_growth
+
+    return pe_value, peg_value
 
 
-def ensure_pe_ratio(symbol: str, symbol_dir: str, *, stale_after_days: int = 7) -> PERatio:
-    """Ensure a cached P/E ratio exists for ``symbol``.
-
-    The ratio is cached under ``symbol_dir`` in ``fundamentals.json``. When the
-    cached data is older than ``stale_after_days`` (default seven days) or
-    missing entirely, a fresh lookup is attempted.
-    """
+def ensure_fundamental_ratios(
+    symbol: str, symbol_dir: str, *, stale_after_days: int = 7
+) -> FundamentalRatios:
+    """Ensure cached fundamental ratios exist for ``symbol``."""
 
     os.makedirs(symbol_dir, exist_ok=True)
     fundamentals_path = os.path.join(symbol_dir, FUNDAMENTALS_FILENAME)
-    cached_value, cached_as_of = _load_cached(fundamentals_path)
+    cached_pe, cached_peg, cached_as_of, cached_has_peg = _load_cached(
+        fundamentals_path
+    )
     today_iso = _dt.date.today().isoformat()
 
-    needs_refresh = True
+    needs_refresh = False
     if cached_as_of:
         age = _days_between(cached_as_of, today_iso)
         needs_refresh = age is None or age > stale_after_days
-    elif cached_value is not None:
-        # Value but no date → refresh to attach an "as of" timestamp.
+    else:
         needs_refresh = True
 
-    if not needs_refresh and cached_as_of and cached_value is not None:
-        return PERatio(cached_value, cached_as_of)
+    if not cached_has_peg:
+        needs_refresh = True
 
-    fetched_value = fetch_pe_ratio(symbol)
-    if fetched_value is not None:
-        payload = {
-            "symbol": symbol,
-            "pe_ratio": float(fetched_value),
-            "as_of": today_iso,
-            "source": "yfinance",
-        }
-        try:
-            with open(fundamentals_path, "w", encoding="utf-8") as fh:
-                json.dump(payload, fh, indent=2, sort_keys=True)
-                fh.write("\n")
-        except Exception:
-            pass
-        return PERatio(float(fetched_value), today_iso)
+    if cached_pe is None or cached_peg is None:
+        needs_refresh = True
 
-    if cached_value is not None or cached_as_of is not None:
-        return PERatio(cached_value, cached_as_of)
+    if (
+        not needs_refresh
+        and cached_as_of
+        and (cached_pe is not None or cached_peg is not None)
+    ):
+        if not cached_has_peg:
+            _write_cache(
+                fundamentals_path,
+                symbol=symbol,
+                pe_value=cached_pe,
+                peg_value=cached_peg,
+                as_of=cached_as_of,
+            )
+        return FundamentalRatios(
+            PERatio(cached_pe, cached_as_of),
+            PEGRatio(cached_peg, cached_as_of),
+        )
 
-    # No cached data and lookup failed – record an explicit miss so that
-    # downstream code still has a dated entry.
+    fetched_pe, fetched_peg = fetch_fundamental_ratios(symbol)
+    if fetched_pe is not None or fetched_peg is not None:
+        _write_cache(
+            fundamentals_path,
+            symbol=symbol,
+            pe_value=fetched_pe,
+            peg_value=fetched_peg,
+            as_of=today_iso,
+        )
+        return FundamentalRatios(
+            PERatio(fetched_pe, today_iso),
+            PEGRatio(fetched_peg, today_iso),
+        )
+
+    if cached_pe is not None or cached_peg is not None or cached_as_of is not None:
+        if not cached_has_peg:
+            _write_cache(
+                fundamentals_path,
+                symbol=symbol,
+                pe_value=cached_pe,
+                peg_value=cached_peg,
+                as_of=cached_as_of,
+            )
+        return FundamentalRatios(
+            PERatio(cached_pe, cached_as_of),
+            PEGRatio(cached_peg, cached_as_of),
+        )
+
     payload = {
         "symbol": symbol,
         "pe_ratio": None,
+        "peg_ratio": None,
         "as_of": today_iso,
         "source": "yfinance",
     }
-    try:
-        with open(fundamentals_path, "w", encoding="utf-8") as fh:
-            json.dump(payload, fh, indent=2, sort_keys=True)
-            fh.write("\n")
-    except Exception:
-        pass
-    return PERatio(None, today_iso)
+    _write_cache(
+        fundamentals_path,
+        symbol=symbol,
+        pe_value=None,
+        peg_value=None,
+        as_of=today_iso,
+    )
+    return FundamentalRatios(PERatio(None, today_iso), PEGRatio(None, today_iso))
 
 
-__all__ = ["PERatio", "ensure_pe_ratio"]
+def ensure_pe_ratio(symbol: str, symbol_dir: str, *, stale_after_days: int = 7) -> PERatio:
+    """Backward-compatible wrapper returning only the P/E ratio."""
+
+    ratios = ensure_fundamental_ratios(
+        symbol, symbol_dir, stale_after_days=stale_after_days
+    )
+    return ratios.pe_ratio
+
+
+def ensure_peg_ratio(symbol: str, symbol_dir: str, *, stale_after_days: int = 7) -> PEGRatio:
+    """Ensure a cached PEG ratio exists for ``symbol``."""
+
+    ratios = ensure_fundamental_ratios(
+        symbol, symbol_dir, stale_after_days=stale_after_days
+    )
+    return ratios.peg_ratio
+
+
+__all__ = [
+    "PERatio",
+    "PEGRatio",
+    "FundamentalRatios",
+    "ensure_fundamental_ratios",
+    "ensure_pe_ratio",
+    "ensure_peg_ratio",
+]


### PR DESCRIPTION
## Summary
- extend the fundamentals fetcher to combine yfinance growth estimates with a Finviz HTML fallback so cached PEG values are filled in instead of remaining empty
- add a unit test covering the Finviz fallback path
- refresh fundamentals caches, symbol summaries, and aggregated stats so PEG ratios now contain real numbers alongside their P/E counterparts

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cff8e89424832d859333e55925e1d3