### PR TITLE
Add CRM2x leveraged experiment

### DIFF
--- a/EXPERIMENTS.md
+++ b/EXPERIMENTS.md
@@ -39,6 +39,16 @@ heats up. Invoke it with `python optimize_leveraged_symbol.py --symbol TSLA --le
 
 - **CAGR**: ~91.9% on TSLA with 2x leverage (through 2025‑09‑19)
 
+## CRM2x – Salesforce 2x Baseline Optimiser
+Applies the leveraged optimiser to Salesforce (CRM) while emulating a 2x sleeve
+similar to geared single-stock ETFs. CRM’s steadier trend profile lets the
+search keep a relatively high mid-temperature allocation while leaning on a
+modest rate taper to control leverage costs. The tuned configuration lifts the
+2x CAGR from roughly 30.5% under the baseline A1g settings to just under 36.8%.
+Recreate the parameters with `python optimize_leveraged_symbol.py --symbol CRM --leverage 2.0`.
+
+- **CAGR**: ~36.8% on CRM with 2x leverage (through 2025‑09‑19)
+
 ## A2 – Cold Leverage Boost
 Adds a "cold leverage" rule that increases TQQQ exposure by 20% (capped at 120%) when
 market temperature is below 0.8, interest rates are under 5%, and the 22‑day return is

--- a/strategy_tqqq_reserve.py
+++ b/strategy_tqqq_reserve.py
@@ -1451,6 +1451,44 @@ EXPERIMENTS["TESLA2X"] = {
 }
 EXPERIMENTS["TESLA2x"] = {**EXPERIMENTS["TESLA2X"]}
 
+# CRM2X tunes the leveraged optimiser for Salesforce with a 2x sleeve
+EXPERIMENTS["CRM2X"] = {
+    "temperature_allocation": [
+        {"temp": 0.943276238479186, "allocation": 1.300935182207879},
+        {"temp": 1.0, "allocation": 1.1},
+        {"temp": 1.2851226598530594, "allocation": 0.07214073410116358},
+    ],
+    "momentum_filters": {
+        "buy": {
+            "ret3": -0.009934536318049225,
+            "ret6": 0.0010685452318550104,
+            "ret12": 0.006707013120519407,
+            "ret22": -0.0033135814935658452,
+            "temp": 1.3449941220997192,
+        },
+        "sell": {
+            "ret3": 0.09028928135700337,
+            "ret6": 0.013594010399651791,
+            "ret12": -0.026122410893363583,
+            "ret22": 0.004031251686438176,
+        },
+    },
+    "rate_taper": {
+        "start": 10.63726107519519,
+        "end": 13.207353213335777,
+        "min_allocation": 0.17858434211873486,
+        "enabled": True,
+    },
+    "crash_derisk": {
+        "enabled": False,
+        "threshold": None,
+        "cooldown_days": 22,
+    },
+    "rebalance_days": 22,
+    "leverage_override": 2.0,
+}
+EXPERIMENTS["CRM2x"] = {**EXPERIMENTS["CRM2X"]}
+
 # A5 builds on A4 with a macro risk-off filter
 EXPERIMENTS["A5"] = {
     **EXPERIMENTS["A4"],


### PR DESCRIPTION
## Summary
- add a CRM2x leveraged experiment tuned for Salesforce and expose its alias
- document the CRM2x configuration in the experiments catalog with performance context

## Testing
- python -m pytest test_strategy_experiments.py

------
https://chatgpt.com/codex/tasks/task_e_68d059d9aa78832db57fb43278d76961