### PR TITLE
Retune TESLA2X_B2 parameters and support manual temperature

### DIFF
--- a/EXPERIMENTS.md
+++ b/EXPERIMENTS.md
@@ -62,6 +62,8 @@ temperature series aligned with that future reference point instead of relying
 on the iterative best fit. Invoke it with `--experiment TESLA2X_B2` (aliases:
 TESLA2XB2, TESLA2X.B2, TESLA2X.B.2, TESLA2x.b.2).
 
+- **CAGR**: ~94.8% on TSLA with 2x leverage (through 2025-09-19)
+
 ## CRM2x – Salesforce 2x Baseline Optimiser
 Applies the leveraged optimiser to Salesforce (CRM) while emulating a 2x sleeve
 similar to geared single-stock ETFs. CRM’s steadier trend profile lets the

--- a/strategy_tqqq_reserve.py
+++ b/strategy_tqqq_reserve.py
@@ -1557,7 +1557,40 @@ EXPERIMENTS["TESLA2X_B"] = {
 EXPERIMENTS["TESLA2XB"] = {**EXPERIMENTS["TESLA2X_B"]}
 EXPERIMENTS["TESLA2X.B"] = {**EXPERIMENTS["TESLA2X_B"]}
 EXPERIMENTS["TESLA2X_B2"] = {
-    **EXPERIMENTS["TESLA2X_B"],
+    "temperature_allocation": [
+        {"temp": 0.96, "allocation": 1.4127335097450804},
+        {"temp": 1.0, "allocation": 0.6235814915136063},
+        {"temp": 1.415107584436503, "allocation": 0.36725481379369734},
+    ],
+    "momentum_filters": {
+        "buy": {
+            "ret3": -0.00331388609681018,
+            "ret6": -0.07879806096063681,
+            "ret12": -0.019793671351911266,
+            "ret22": None,
+            "temp": 1.2705193487109943,
+        },
+        "sell": {
+            "ret3": 0.014474113635472498,
+            "ret6": 0.03219641555473544,
+            "ret12": 0.018856549318460862,
+            "ret22": -0.006053415800481365,
+        },
+    },
+    "rate_taper": {
+        "start": 10.71788387408976,
+        "end": 11.500051848273712,
+        "min_allocation": 0.17682479689547168,
+        "enabled": True,
+    },
+    "crash_derisk": {
+        "enabled": False,
+        "threshold": None,
+        "cooldown_days": 22,
+    },
+    "rebalance_days": 22,
+    "leverage_override": 2.0,
+    "base_symbol": "TSLA",
     "temperature_model": {
         "growth_rate": 0.42,
         "anchor_date": "2025-09-18",

--- a/symbols/tsla/tsla_TESLA2X_B2_summary.md
+++ b/symbols/tsla/tsla_TESLA2X_B2_summary.md
@@ -1,0 +1,16 @@
+# TSLA – Strategy TESLA2X_B2 Summary
+
+- **Span**: 2010-06-29 → 2025-09-19 (15.23 years)
+- **Underlying (TSLA price) CAGR**: 44.35%
+- **Fitted curve CAGR**: 42.00%
+- **Strategy CAGR**: 94.80%
+- **Max drawdown**: -94.69%
+- **Rebalances executed**: 91
+- **P/E ratio (as of 2025-09-21)**: 256.67
+- **PEG ratio (as of 2025-09-21)**: N/A
+- **Current growth rate (as of 2025-09-21)**: -16.30%
+
+Notes:
+
+- Temperatures and anchors per experiment govern deployment; see EXPERIMENTS.md for details.
+- Figures use simulated leveraged sleeve with fees and borrow costs.


### PR DESCRIPTION
## Summary
- allow the leveraged optimiser to reuse manual temperature models defined on experiments
- retune the TESLA2X_B2 experiment with the new optimiser output and document the updated CAGR
- refresh the TSLA TESLA2X_B2 strategy summary to reflect the new configuration

## Testing
- python optimize_leveraged_symbol.py --symbol TSLA --leverage 2.0 --baseline TESLA2X_B2 --iterations 180 --seed 4
- python strategy_tqqq_reserve.py --experiment TESLA2X_B2 --base-symbol TSLA --leverage 2.0 --no-show


------
https://chatgpt.com/codex/tasks/task_e_68d0aecb49e4832d8f46c960d9172527