### PR TITLE
Allow integration requests without explicit last rebalance date

### DIFF
--- a/docs/integration_investments_view.md
+++ b/docs/integration_investments_view.md
@@ -15,17 +15,20 @@ The bridge lives in `strategy_tqqq_reserve.py` and is available in two forms:
 
 ## Request schema
 
-Every request must include the model to evaluate, the date of the last
-completed rebalance, and the current holdings expressed in dollars (share
-counts are optional but improve the share-level output). All symbol and market
-data settings default to the chosen experiment, but the caller may override
+Every request must include the model to evaluate and the current holdings
+expressed in dollars (share counts are optional but improve the share-level
+output). Providing the date of the last completed rebalance lets the simulator
+reconstruct drift accurately, but when InvestmentsView is onboarding a fresh
+account the field may be omitted and the bridge will assume the last rebalance
+occurred on the request date. All symbol and market data settings default to the
+chosen experiment, but the caller may override
 them when necessary (e.g., to test a custom CSV or a different reserve asset).
 
 ```jsonc
 {
   "experiment": "A1",               // required – strategy experiment key
   "request_date": "2025-09-19",     // required – evaluation date (trading day)
-  "last_rebalance": "2025-09-01",   // required – last executed rebalance (string or object)
+  "last_rebalance": "2025-09-01",   // optional – last executed rebalance (string or object)
   "positions": [                     // required – current holdings as of request_date
     {"symbol": "TQQQ", "dollars": 2150.25, "shares": 31.5},
     {"symbol": "SGOV", "dollars": 3150.00}
@@ -51,7 +54,10 @@ Optional keys mirror the CLI arguments and override the experiment defaults:
 
 When richer audit detail is available, `last_rebalance` may be provided as an
 object (e.g., `{ "date": "2025-09-01", "note": "Quarterly rebalance" }`). Only
-the `date` field is required; extra keys are ignored by the bridge.
+the `date` field is required; extra keys are ignored by the bridge. If the field
+is omitted entirely, the simulator seeds its state using the request date so
+newly created portfolios can obtain their first trade recommendation without
+supplying historical activity.
 
 The simulator reconstructs the original rebalance state by inferring share
 counts from the supplied dollar amounts and each symbol’s adjusted close on the

--- a/test_integration_bridge.py
+++ b/test_integration_bridge.py
@@ -1,0 +1,26 @@
+import pytest
+
+pd = pytest.importorskip("pandas")
+
+from strategy_tqqq_reserve import evaluate_integration_request
+
+
+def test_evaluate_request_without_last_rebalance():
+    payload = {
+        "experiment": "A1",
+        "request_date": "2024-06-03",
+        "positions": [],
+    }
+
+    response = evaluate_integration_request(payload)
+
+    assert response["request_date"] == payload["request_date"]
+    assert response["recent_rebalance"] is None
+    assert response["model"]["days_since_last_rebalance"] == 0
+
+    symbols = {pos["symbol"] for pos in response["current_positions"]}
+    assert symbols == {"QQQ", "TQQQ", "CASH"}
+
+    # The bridge should still return a valid decision block.
+    assert response["decision"]["action"] in {"rebalance", "hold"}
+    assert isinstance(response["decision"]["reason"], str) and response["decision"]["reason"]


### PR DESCRIPTION
## Summary
- allow the integration bridge to infer the last rebalance date from the request when the payload omits it
- update the bridge response metadata and documentation to reflect the optional last_rebalance field
- add a regression test covering integration requests that start without prior trades

## Testing
- pytest test_integration_bridge.py

------
https://chatgpt.com/codex/tasks/task_e_68db3b061658832db6dd2f55ef241e1f