### PR TITLE
Fix initial rebalance blocking when no last rebalance is provided

### DIFF
--- a/strategy_tqqq_reserve.py
+++ b/strategy_tqqq_reserve.py
@@ -4074,12 +4074,19 @@ def evaluate_integration_request(payload: Mapping[str, Any]) -> Dict[str, Any]:
         no_show=True,
     )
 
+    next_rebalance_idx_override = rebalance_cadence
+    last_rebalance_idx_override = 0
+    if implied_last_rebalance:
+        # With no recorded rebalance we should treat the current window as immediately
+        # eligible so the bridge can surface the initial deployment trades.
+        next_rebalance_idx_override = 0
+
     overrides = BacktestOverrides(
         initial_unlevered=initial_unlevered,
         initial_leveraged=initial_leveraged,
         initial_cash=initial_cash,
-        last_rebalance_index=0,
-        next_rebalance_index=rebalance_cadence,
+        last_rebalance_index=last_rebalance_idx_override,
+        next_rebalance_index=next_rebalance_idx_override,
         allow_rebalances_from_index=allow_index,
         capture_decision_log=True,
     )

--- a/test_integration_bridge.py
+++ b/test_integration_bridge.py
@@ -40,9 +40,9 @@ def test_evaluate_request_without_last_rebalance():
     }
     assert symbols == expected_symbols
 
-    # The bridge should still return a valid decision block.
-    assert response["decision"]["action"] in {"rebalance", "hold"}
-    assert isinstance(response["decision"]["reason"], str) and response["decision"]["reason"]
+    # The bridge should request an immediate rebalance to establish the initial position.
+    assert response["decision"]["action"] == "rebalance"
+    assert response["decision"]["reason"] == "Rebalance required by strategy rules."
 
 
 def test_evaluate_request_with_weekend_last_rebalance():


### PR DESCRIPTION
## Summary
- allow the integration bridge to treat the current window as immediately eligible when no prior rebalance is supplied
- update the integration test to expect an immediate rebalance recommendation in the initial funding scenario

## Testing
- pytest -q test_integration_bridge.py


------
https://chatgpt.com/codex/tasks/task_e_68db45106bd4832d9f7315896842f77e