### PR TITLE
Adjust buy temperature block messaging

### DIFF
--- a/docs/integration_investments_view.md
+++ b/docs/integration_investments_view.md
@@ -127,8 +127,9 @@ rebalance. A typical rebalance recommendation looks like:
 When the model elects to hold, the response still includes the model’s desired
 weights so InvestmentsView can surface drift information, and the `reason`
 string explains which cadence or momentum rule blocked trading (e.g. “Next
-rebalance window opens in 5 trading day(s).” or “Buy-side momentum guard active”
-when a drawdown filter is engaged).【F:strategy_tqqq_reserve.py†L4497-L4541】
+rebalance window opens in 5 trading day(s).”, “Buy-side momentum guard active”
+when a drawdown filter is engaged, or “Buy prevented by violation of maximum
+temperature of 1.30.” when only the temperature limit blocks the trade).
 
 ## Consuming the bridge
 


### PR DESCRIPTION
## Summary
- capture the configured buy temperature limit in logged decisions
- surface a dedicated message when buys are blocked only by the temperature cap
- document the updated messaging example for integration consumers

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db47a0861c832d9cf90bec550d95f7