### PR TITLE
Allow aligning future integration dates to the latest market data

### DIFF
--- a/strategy_tqqq_reserve.py
+++ b/strategy_tqqq_reserve.py
@@ -3966,6 +3966,9 @@ def evaluate_integration_request(payload: Mapping[str, Any]) -> Dict[str, Any]:
             aligned_day = aligned.normalize()
             target_day = ts.normalize()
 
+            if target_day > index_sorted[-1].normalize():
+                target_day = index_sorted[-1].normalize()
+
             if hasattr(np, "busday_count"):
                 lag_days = int(np.busday_count(aligned_day.strftime("%Y-%m-%d"), target_day.strftime("%Y-%m-%d")))
             else:


### PR DESCRIPTION
## Summary
- adjust request-date alignment to clamp future dates to the most recent price history before validating lag thresholds

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68e47be32120832d807541bf06626aab